### PR TITLE
[AMSDK-7323] Updated extension registration error handling section and added tabs for ios/android code

### DIFF
--- a/resources/building-mobile-extensions/building-an-extension.md
+++ b/resources/building-mobile-extensions/building-an-extension.md
@@ -4,7 +4,7 @@
 
 Before you build an extension, complete the following tasks:
 
-* Ensure that you are using the Adobe Cloud Platform SDKs.
+* Ensure that you are using the Adobe Experience Platform SDKs.
 
   Extensions extend the behavior of these SDKs.
 
@@ -23,15 +23,15 @@ Before you build an extension, complete the following tasks:
 
   Extensions for iOS can currently only be built using Objective-C, and extensions on Android can currently only be built using Java.
 
-* Ensure that you have already included the Adobe Cloud Platform SDKs in your project.
+* Ensure that you have already included the Adobe Experience Platform SDKs in your project.
 
-## Implementing an Adobe Cloud Platform SDK Extension
+## Implementing an Adobe Experience Platform SDK Extension
 
 To create a simple extension, complete the following procedures in the order in which they are listed:
 
 ### A. **Create an Extension Class**
 
-The `ACPExtension`\(iOS\) or `Extension` \(Android\) class is the base class that any extensions must derive from. The `init` method \(iOS\) or the base `constructor` \(Android\) of your extension class is where you will have the opportunity to extend the Adobe Cloud Platform SDKs functionality by registering event listeners, or by setting a default shared state that other modules can access.
+The `ACPExtension`\(iOS\) or `Extension` \(Android\) class is the base class that any extensions must derive from. The `init` method \(iOS\) or the base `constructor` \(Android\) of your extension class is where you will have the opportunity to extend the Adobe Experience Platform SDKs functionality by registering event listeners, or by setting a default shared state that other modules can access.
 
 #### **iOS**
 
@@ -45,8 +45,8 @@ The `ACPExtension` class has the following method that you must override:
 The `ACPExtension` class has the following methods that you can optionally override and a member that provides access to the Event Hub:
 
 * `version`, which returns a version string for your extension.    The version string is only used for logging and is currently not validated for formatting. 
-* `onUnregister`, which allows your extension to complete the cleanup that is required when the Adobe Cloud Platform SDK unregisters your extension.    Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
-* `unexpectedError`, which allows you log additional information when the Adobe Cloud Platform SDKs encounter an error that could not be returned immediately from a call into the SDK.    An example is an exception that is thrown on a worker thread. The exceptions are rare after your extension has been correctly implemented, but the exceptions might occur during development.
+* `onUnregister`, which allows your extension to complete the cleanup that is required when the Adobe Experience Platform SDK unregisters your extension.    Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
+* `unexpectedError`, which allows you log additional information when the Adobe Experience Platform SDKs encounter an error that could not be returned immediately from a call into the SDK.    An example is an exception that is thrown on a worker thread. The exceptions are rare after your extension has been correctly implemented, but the exceptions might occur during development.
 * `api` , allows the extension developer to interact with the Event Hub to register event listeners, manage shared state, and so on.  This method can be used at any time during or after init has been called on your extension. It may also be used by your listeners by using the extension member.        **Tip**: The ACPExtension class provides access to the `ACPExtensionApi` interface through the API member.  
 
 #### **iOS code example**
@@ -119,12 +119,12 @@ The `Extension` class has the following method that you must override:
 
 **Tip**: All Adobe module names are prefixed with _com.adobe.module_ and are considered reserved.
 
-* `onUnregistered`, which allows your extension to complete the cleanup that is required when the Adobe Cloud Platform SDK unregisters your extension.  Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
+* `onUnregistered`, which allows your extension to complete the cleanup that is required when the Adobe Experience Platform SDK unregisters your extension.  Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
 
 The `Extension` class has the following methods that you can optionally override and a member that provides access to the Event Hub:
 
 * `getVersion`, which returns a version string for your extension. The version string is only used for logging and is currently not validated for formatting.
-* `onUnexpectedError`, which allows you log additional information when the Adobe Experience Cloud Platform SDK encounters an error that could not be returned immediately from a call into the Adobe Cloud Platform SDK.  An example is an exception that is thrown on a worker thread. The exceptions are rare after your extension has been correctly implemented, but the exceptions might occur during development.
+* `onUnexpectedError`, which allows you log additional information when the Adobe Experience Cloud Platform SDK encounters an error that could not be returned immediately from a call into the Adobe Experience Platform SDK.  An example is an exception that is thrown on a worker thread. The exceptions are rare after your extension has been correctly implemented, but the exceptions might occur during development.
 * `getApi` , allows the extension developer to interact with the Event Hub to register event listeners, manage shared state, and so on.
 
   This method can be used at any after the extension registration is complete. It may also be used by your listeners by using the extension member.
@@ -156,15 +156,15 @@ class MyExtension extends Extension {
 
 ### B. **Registering your Extension**
 
-After creating your extension class, you can register it by using the `ACPCore` method `registerExtension`. Some registration errors, such as undefined names, name conflicts, or type checking issues, occur immediately. Other errors might occur asynchronously and are reported through the `unexpectedError` callback before the extension is unregistered.
+After creating your extension class, you can register it by using the `ACPCore` (iOS) or `MobileCore` (Android) method `registerExtension`. During registration, the extension class that you passed will be used by the Adobe Experience Platform SDKs to create an instance of your extension that will be retained until your extension is unregistered.
 
 **Tip**: Registration can be completed any time after the app is launched.
-
-During registration, the extension class that you passed will be used by the Adobe Cloud Platform SDKs to create an instance of your extension that will be retained until your extension is unregistered.
 
 #### iOS
 
 A convenient place to register your extension on iOS is in your AppDelegate's `application:didFinishLaunchingWithOptions:` method.
+
+**Note:** Some registration errors, such as undefined names, name conflicts, or type checking issues, occur immediately. Other errors might occur asynchronously and are reported through the `unexpectedError` callback before the extension is unregistered.
 
 ```objectivec
 #import <ACPCore_iOS/ACPCore_iOS.h>
@@ -196,6 +196,8 @@ A convenient place to register your extension on iOS is in your AppDelegate's `a
 
 A convenient place to register your extension on Android is in the `onCreate` method of your activity.
 
+**Note:** Some registration errors, such as sending a null extension class as parameter, are synchronous and occur immediately. Other errors like undefined names, name conflicts, or type checking issues, might occur asynchronously and are reported through the `onUnexpectedError` callback before the extension is unregistered.
+
 ```java
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.ExtensionError;
@@ -215,18 +217,27 @@ public void onCreate() {
     if (!MobileCore.registerExtension(MyCustomExtension.class, errorCallback)) {
         Log.e("Extensions", "Failed to register the MyCustomExtension extension");
     }
+    
+    ...
+    MobileCore.start(null);
 }
 ```
 
 ### C. **Unregistering your Extension**
 
-If your extension does not need to be active at all times, you can unregister your extension by using `unregisterExtension` in the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\). This process allows you to have more granular resource control, but the listeners that you registered will be unregistered. If you overrode `onUnregister`, you should see a call into your implementation that allows you to clean up resources before the instance is released.
+If your extension does not need to be active at all times, you can unregister your extension by using `unregisterExtension` from the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\). This process allows you to have more granular resource control, but the listeners that you registered will be unregistered. If you overrode `onUnregister`, you should see a call into your implementation that allows you to clean up resources before the instance is released.
 
 **Tip**: If you retained a reference to the extension instance \(for example by storing `self` or `this` in a static variable\), this is where you should clean it up.
 
 #### iOS
 
-```text
+```objective-c
 [self.api unregisterExtension];
+```
+
+#### Android
+
+```java
+getApi().unregisterExtension();
 ```
 

--- a/resources/building-mobile-extensions/building-an-extension.md
+++ b/resources/building-mobile-extensions/building-an-extension.md
@@ -46,17 +46,12 @@ The `Extension` class has the following method that you must override:
 
 **Tip**: All Adobe module names are prefixed with _com.adobe.module_ and are considered reserved.
 
-- `onUnregistered`, which allows your extension to complete the cleanup that is required when the Adobe Experience Platform SDK unregisters your extension.  Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
-
 The `Extension` class has the following methods that you can optionally override and a member that provides access to the Event Hub:
 
 - `getVersion`, which returns a version string for your extension. The version string is only used for logging and is currently not validated for formatting.
-
+- `onUnregistered`, which allows your extension to complete the cleanup that is required when the Adobe Experience Platform SDK unregisters your extension.  Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
 - `onUnexpectedError`, which allows you log additional information when the Adobe Experience Cloud Platform SDK encounters an error that could not be returned immediately from a call into the Adobe Experience Platform SDK.  An example is an exception that is thrown on a worker thread. The exceptions are rare after your extension has been correctly implemented, but the exceptions might occur during development.
-
-- `getApi` , allows the extension developer to interact with the Event Hub to register event listeners, manage shared state, and so on.
-
-  This method can be used at any after the extension registration is complete. It may also be used by your listeners by using the extension member.
+- `getApi` , allows the extension developer to interact with the Event Hub to register event listeners, manage shared state, and so on. This method can be used at any time after the extension registration is complete. It may also be used by your listeners by calling  `super.getParentExtension().getApi()`.
 
 **Tip**: The `Extension` class provides access to the `ExtensionApi` interface through the `getApi` member.
 
@@ -99,9 +94,14 @@ The `ACPExtension` class has the following method that you must override:
 The `ACPExtension` class has the following methods that you can optionally override and a member that provides access to the Event Hub:
 
 * `version`, which returns a version string for your extension.    The version string is only used for logging and is currently not validated for formatting. 
+
 * `onUnregister`, which allows your extension to complete the cleanup that is required when the Adobe Experience Platform SDK unregisters your extension.    Unregistration typically happens at app shutdown but can also occur when an extension is behaving badly. Examples of the extension behaving badly include taking too long to handle a callback or by throwing an exception.
+
 * `unexpectedError`, which allows you log additional information when the Adobe Experience Platform SDKs encounter an error that could not be returned immediately from a call into the SDK.    An example is an exception that is thrown on a worker thread. The exceptions are rare after your extension has been correctly implemented, but the exceptions might occur during development.
-* `api` , allows the extension developer to interact with the Event Hub to register event listeners, manage shared state, and so on.  This method can be used at any time during or after init has been called on your extension. It may also be used by your listeners by using the extension member.        **Tip**: The ACPExtension class provides access to the `ACPExtensionApi` interface through the API member.  
+
+* `api` , allows the extension developer to interact with the Event Hub to register event listeners, manage shared state, and so on.  This method can be used at any time during or after init has been called on your extension. It may also be used by your listeners by using the extension member.
+
+  **Tip**: The ACPExtension class provides access to the `ACPExtensionApi` interface through the API member.  
 
 #### **iOS code example**
 

--- a/resources/building-mobile-extensions/building-an-extension.md
+++ b/resources/building-mobile-extensions/building-an-extension.md
@@ -255,7 +255,7 @@ Some registration errors, such as undefined names, name conflicts, or type check
 
 {% endtabs %}
 
-#### **C. **Unregistering your Extension
+#### C. Unregistering your Extension
 
 If your extension does not need to be active at all times, you can unregister your extension by using `unregisterExtension` from the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\). This process allows you to have more granular resource control, but the listeners that you registered will be unregistered. If you overrode `onUnregister`, you should see a call into your implementation that allows you to clean up resources before the instance is released.
 

--- a/resources/building-mobile-extensions/clearing-a-shared-state.md
+++ b/resources/building-mobile-extensions/clearing-a-shared-state.md
@@ -7,18 +7,10 @@ Shared states will persist for the life of the application context, which result
 
 **Warning**: You cannot store a user’s personally identifiable information in the shared state.
 
-To allow you to manage identifiers, an API is available that clears all of the existing shared state for your extension without impacting other extensions. The following examples shows you how to call this API in your `onUnregister` \(iOS\) / `onUnregistered` \(Android\) method and ensure a clean state:
+To allow you to manage identifiers, an API is available that clears all of the existing shared state for your extension without impacting other extensions. The following examples shows you how to call this API in your `onUnregister` \(iOS\) / `onUnregistered` \(Android\) method and ensure a clean state.
 
-## iOS
-
-```text
-- (void) onUnregister {
-    NSError* error = nil;
-    if (![self.api clearSharedEventStates:&error] && error) {
-        NSLog(@"Error clearing shared states for extension: %@ %ld", [error domain], [error code]);
-    }
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ## Android
 
@@ -35,3 +27,20 @@ public void onUnregistered() {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+## iOS
+
+```text
+- (void) onUnregister {
+    NSError* error = nil;
+    if (![self.api clearSharedEventStates:&error] && error) {
+        NSLog(@"Error clearing shared states for extension: %@ %ld", [error domain], [error code]);
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/dispatching-events-from-your-extension.md
+++ b/resources/building-mobile-extensions/dispatching-events-from-your-extension.md
@@ -19,28 +19,8 @@ When constructing an event, errors might be returned for the following reasons:
 
 In the example below, a custom event called `MyCustomEvent` is created with custom types and sources. The internal modules will not respond to an event like this because they will not be listening for it. You can add an event listener for this type and source to verify that it is working.
 
-#### iOS
-
-To create events in iOS, you must first import `ACPExtensionEvent.h` from the `ACPCore` framework:
-
-```text
-#import "ACPCore_iOS/ACPExtensionEvent.h"
-...
-NSError* error = nil;
-NSDictionary* eventData = @{
-            @"id" : @"clickid53",
-            @"localTemp": @72.6,
-            @"pageClicks" : @23,
-            @"pageOrder" : @[@1,@2,@3,@4]
-};
-ACPExtensionEvent* newEvent = [ACPExtensionEvent extensionEventWithName:@"MyCustomEvent"          type:@"com.myCompany.eventType.custom"
-        source:@"com.myCompany.eventSource.custom" 
-        data:eventData
-        error:&error];
-if (error) {
-    NSLog(@"Error constructing new event %@:%ld", [error domain], [error code]);
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 #### Android
 
@@ -65,28 +45,44 @@ Event newEvent = new Event.Builder("MyCustomEvent",
                                    .setEventData(eventData).build();
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+#### iOS
+
+To create events in iOS, you must first import `ACPExtensionEvent.h` from the `ACPCore` framework:
+
+```objective-c
+#import "ACPCore_iOS/ACPExtensionEvent.h"
+...
+NSError* error = nil;
+NSDictionary* eventData = @{
+            @"id" : @"clickid53",
+            @"localTemp": @72.6,
+            @"pageClicks" : @23,
+            @"pageOrder" : @[@1,@2,@3,@4]
+};
+ACPExtensionEvent* newEvent = [ACPExtensionEvent extensionEventWithName:@"MyCustomEvent"          type:@"com.myCompany.eventType.custom"
+        source:@"com.myCompany.eventSource.custom" 
+        data:eventData
+        error:&error];
+if (error) {
+    NSLog(@"Error constructing new event %@:%ld", [error domain], [error code]);
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
 ### Dispatch your Event
 
 After creating your event, dispatch it by using the `ACPCore` \(iOS\) / `MobileCore` \(Android\) method `dispatchEvent`. A typical place to dispatch an event is in an event listener.
 
 In some cases, you may need to dispatch an event from one of your public APIs or application methods in order to trigger an internal flow in your own extension or in other Adobe extension.
 
-#### iOS
-
-```text
-#import "ACPCore_iOS/ACPExtensionEvent.h"
-
-- (IBAction) loginButtonClicked:(id)sender {
-    // construct the event to dispatch (see above)
-    ACPExtensionEvent* newEvent = ...;
-
-    // dispatch the event
-    NSError* error = nil;
-    if (![ACPCore dispatchEvent:newEvent error:&error] && error) {
-        NSLog(@"Error dispatching event %@:%ld", [error domain], [error code]);
-    };
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 #### Android
 
@@ -115,6 +111,30 @@ public void loginButtonClicked() {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+#### iOS
+
+```objective-c
+#import "ACPCore_iOS/ACPExtensionEvent.h"
+
+- (IBAction) loginButtonClicked:(id)sender {
+    // construct the event to dispatch (see above)
+    ACPExtensionEvent* newEvent = ...;
+
+    // dispatch the event
+    NSError* error = nil;
+    if (![ACPCore dispatchEvent:newEvent error:&error] && error) {
+        NSLog(@"Error dispatching event %@:%ld", [error domain], [error code]);
+    };
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
 ### Dispatch Paired Events
 
 If you need to use a request `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) as a trigger, and you have a callback to be called when the response paired event is sent, you can use the `dispatchEventWithResponseCallback` API from `ACPCore` \(iOS\) / `MobileCore` \(Android\). Then, the paired response event should be sent using the `dispatchResponseEvent` API.
@@ -123,76 +143,8 @@ If you need to use a request `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) a
 
 Here is an example of how to implement this:
 
-#### IOS
-
-You can have this code in a ViewController class or in one of your extensions public API classes:
-
-```text
-// how to dispatch a paired event with an associated response callback
-NSError *eventError = nil;
-ACPExtensionEvent *event = [ACPExtensionEvent 
-extensionEventWithName:@"Dispatch Request Event with Callback"
-                  type:@"com.myCompany.eventType.custom"
-                source:@"com.myCompany.eventSource.request"
-                  data:@{}
-                 error:&eventError];
-
-if (!event && eventError) {
-    NSLog(@"An error occurred while constructing event '%@': %ld", event.eventName, [eventError code]);
-    return;
-}
-
-// dispatch the event and handle the callback
-NSError *dispatchError = nil;
-if ([ACPCore dispatchEventWithResponseCallback:event responseCallback:^(ACPExtensionEvent * _Nonnull responseEvent) {
-    NSLog(@"Response event received, with type %@, source %@ and data %@", responseEvent.eventType, responseEvent.eventSource, responseEvent.eventData);
-        // process event data
-} error:&dispatchError]) {
-    NSLog(@"Dispatched a paired request event '%@'", event.eventName);
-} else if (dispatchError) {
-    NSLog(@"An error occurred dispatching event '%@': %ld", event.eventName, [dispatchError code]);
-}
-...
-```
-
-Register a listener for this event type and source in MyExtension.m:
-
-```text
-// register a listener for a the request event type and source
-- (instancetype) init {
-    if (self = [super init]) {
-        NSError *error = nil;
-        if ([self.api registerListener:[MyExtensionListener class]
-                             eventType:@"com.myCompany.eventType.custom"
-                           eventSource:@"com.myCompany.eventSource.request"
-                                 error:&error]) {
-               NSLog(@"MyExtensionListener successfully registered for request events");
-         } else if (error) {
-            NSLog(@"There was an error registering MyExtensionListener: %ld", [error code]);
-         }
-...
-}
-```
-
-Dispatch a response event when the request is received in the `hear` method of your Listener in MyListener.m:
-
-```text
-- (void) hear: (nonnull ACPExtensionEvent*) event {
-    NSError *dispatchError = nil;
-    NSDictionary* responseData = @{@"responsekey": @"responsevalue"};
-    ACPExtensionEvent* responseEvent = [ACPExtensionEvent 
-    extensionEventWithName:@"Paired Response Event"                                                                                             type:@"com.myCompany.eventType.custom"                                                                                             source:@"com.myCompany.eventSource.response"
-                      data:responseData
-                     error:&dispatchError];
-
-    // sending a paired response event for the request event
-    if ([ACPCore dispatchResponseEvent:responseEvent requestEvent:event error:&dispatchError]) {
-        NSLog(@"Dispatched response event with data '%@'", responseData);
-    } else if (dispatchError) {
-        NSLog(@"An error occurred dispatching response event : %ld", [dispatchError code]);
-    }
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 #### Android
 
@@ -264,3 +216,80 @@ public class MyListener extends ExtensionListener {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+#### iOS
+
+You can have this code in a ViewController class or in one of your extensions public API classes:
+
+```objective-c
+// how to dispatch a paired event with an associated response callback
+NSError *eventError = nil;
+ACPExtensionEvent *event = [ACPExtensionEvent 
+extensionEventWithName:@"Dispatch Request Event with Callback"
+                  type:@"com.myCompany.eventType.custom"
+                source:@"com.myCompany.eventSource.request"
+                  data:@{}
+                 error:&eventError];
+
+if (!event && eventError) {
+    NSLog(@"An error occurred while constructing event '%@': %ld", event.eventName, [eventError code]);
+    return;
+}
+
+// dispatch the event and handle the callback
+NSError *dispatchError = nil;
+if ([ACPCore dispatchEventWithResponseCallback:event responseCallback:^(ACPExtensionEvent * _Nonnull responseEvent) {
+    NSLog(@"Response event received, with type %@, source %@ and data %@", responseEvent.eventType, responseEvent.eventSource, responseEvent.eventData);
+        // process event data
+} error:&dispatchError]) {
+    NSLog(@"Dispatched a paired request event '%@'", event.eventName);
+} else if (dispatchError) {
+    NSLog(@"An error occurred dispatching event '%@': %ld", event.eventName, [dispatchError code]);
+}
+...
+```
+
+Register a listener for this event type and source in MyExtension.m:
+
+```objective-c
+// register a listener for a the request event type and source
+- (instancetype) init {
+    if (self = [super init]) {
+        NSError *error = nil;
+        if ([self.api registerListener:[MyExtensionListener class]
+                             eventType:@"com.myCompany.eventType.custom"
+                           eventSource:@"com.myCompany.eventSource.request"
+                                 error:&error]) {
+               NSLog(@"MyExtensionListener successfully registered for request events");
+         } else if (error) {
+            NSLog(@"There was an error registering MyExtensionListener: %ld", [error code]);
+         }
+...
+}
+```
+
+Dispatch a response event when the request is received in the `hear` method of your Listener in MyListener.m:
+
+```objective-c
+- (void) hear: (nonnull ACPExtensionEvent*) event {
+    NSError *dispatchError = nil;
+    NSDictionary* responseData = @{@"responsekey": @"responsevalue"};
+    ACPExtensionEvent* responseEvent = [ACPExtensionEvent 
+    extensionEventWithName:@"Paired Response Event"                                                                                             type:@"com.myCompany.eventType.custom"                                                                                             source:@"com.myCompany.eventSource.response"
+                      data:responseData
+                     error:&dispatchError];
+
+    // sending a paired response event for the request event
+    if ([ACPCore dispatchResponseEvent:responseEvent requestEvent:event error:&dispatchError]) {
+        NSLog(@"Dispatched response event with data '%@'", responseData);
+    } else if (dispatchError) {
+        NSLog(@"An error occurred dispatching response event : %ld", [dispatchError code]);
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/dispatching-events-from-your-extension.md
+++ b/resources/building-mobile-extensions/dispatching-events-from-your-extension.md
@@ -77,7 +77,7 @@ if (error) {
 
 ### Dispatch your Event
 
-After creating your event, dispatch it by using the `ACPCore` \(iOS\) / `MobileCore` \(Android\) method `dispatchEvent`. A typical place to dispatch an event is in an event listener.
+After creating your event, dispatch it by using the `ACPCore` \(iOS\) / `MobileCore` \(Android\)  `dispatchEvent` method. A typical place to dispatch an event is in an event listener.
 
 In some cases, you might need to dispatch an event from one of your public APIs or application methods to trigger an internal flow in your extension or another Adobe extension.
 
@@ -137,7 +137,7 @@ public void loginButtonClicked() {
 
 ### Dispatch Paired Events
 
-If you need to use a request `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) as a trigger, and you have a callback to be called when the response paired event is sent, you can use the `dispatchEventWithResponseCallback` API from `ACPCore` \(iOS\) / `MobileCore` \(Android\). Then, the paired response event should be sent using the `dispatchResponseEvent` API.
+If you need to use a request `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) as a trigger, and you have a callback to be called when the response paired event is sent, you can use the `dispatchEventWithResponseCallback` API from `ACPCore` \(iOS\) / `MobileCore` \(Android\). The paired response event is then sent by using  the`dispatchResponseEvent` API.
 
 **Tip:** Paired events are usually used for set/get operations where you need to be notified about a response event outside your extension code.
 

--- a/resources/building-mobile-extensions/dispatching-events-from-your-extension.md
+++ b/resources/building-mobile-extensions/dispatching-events-from-your-extension.md
@@ -79,7 +79,7 @@ if (error) {
 
 After creating your event, dispatch it by using the `ACPCore` \(iOS\) / `MobileCore` \(Android\) method `dispatchEvent`. A typical place to dispatch an event is in an event listener.
 
-In some cases, you may need to dispatch an event from one of your public APIs or application methods in order to trigger an internal flow in your own extension or in other Adobe extension.
+In some cases, you might need to dispatch an event from one of your public APIs or application methods to trigger an internal flow in your extension or another Adobe extension.
 
 {% tabs %}
 {% tab title="Android" %}
@@ -139,7 +139,7 @@ public void loginButtonClicked() {
 
 If you need to use a request `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) as a trigger, and you have a callback to be called when the response paired event is sent, you can use the `dispatchEventWithResponseCallback` API from `ACPCore` \(iOS\) / `MobileCore` \(Android\). Then, the paired response event should be sent using the `dispatchResponseEvent` API.
 
-**Tip:** Paired events are usually used for set/get operations where you need to be notified about a response event outside of your extension code.
+**Tip:** Paired events are usually used for set/get operations where you need to be notified about a response event outside your extension code.
 
 Here is an example of how to implement this:
 

--- a/resources/building-mobile-extensions/event-listeners.md
+++ b/resources/building-mobile-extensions/event-listeners.md
@@ -126,7 +126,7 @@ public class MyExtension extends Extension {
 1. In Xcode, create a new file from the `Cocoa Touch Class` template and save it in your project.
 2. Name your class `MyExtensionListener`, and it should be a subclass to the `ACPExtensionListener` class.
 
-   The `MyExtensionListener.m` file will contain your extension interface declaration and will import `ACPExtensionListener.h`. In the example below, the methods that are available for overriding are also displayed:
+   The `MyExtensionListener.m` file contains your extension interface declaration and imports `ACPExtensionListener.h`. In the example below, the methods that are available for overriding are also displayed:
 
 **MyExtensionListener.h**
 
@@ -178,7 +178,7 @@ public class MyExtension extends Extension {
 
 ### What can you do in your event handler?
 
-Your listener has a reference to the parent extension that registered it. You can use this to centralize logic into your extension class and call into it from your listener. This also means you have access to the extension services API \(`ACPExtensionApi` on iOS and `ExtensionApi` on Android\) provided to the extension. This will allow you to manage your shared states or register additional listeners. You also have access to the core SDK \(`ACPCore`\(iOS\) or `MobileCore` \(Android\). This will allow you to dispatch events and receive responses.
+Your listener has a reference to the parent extension that registered it. You can use this to centralize logic into your extension class and call into it from your listener. This also means you have access to the extension services API \(`ACPExtensionApi` on iOS and `ExtensionApi` on Android\) provided to the extension. This will allow you to manage your shared states or register additional listeners. You also have access to the core SDK \(`ACPCore`\(iOS\) or `MobileCore` \(Android\). This reference will allow you to dispatch events and receive responses.
 
 ## Registering your event listener
 

--- a/resources/building-mobile-extensions/event-listeners.md
+++ b/resources/building-mobile-extensions/event-listeners.md
@@ -14,57 +14,8 @@ Here are some additional rules to remember for event listeners:
 
 ## Creating your event listener
 
-### **iOS**
-
-1. In Xcode create a new file from the `Cocoa Touch Class` template and save it in your project.
-2. Name your class `MyExtensionListener`, and it should be a subclass to the `ACPExtensionListener` class.
-
-   The `MyExtensionListener.m` file will contain your extension interface declaration and will import `ACPExtensionListener.h`. In the example below, the methods that are available for overriding are also displayed:
-
-**MyExtensionListener.h**
-
-```text
-#import <ACPCore_iOS/ACPExtensionListener.h>
-#import <ACPCore_iOS/ACPExtensionEvent.h>
-
-@interface MyExtensionListener : ACPExtensionListener
-    - (void) hear:(ACPExtensionEvent *)event;
-@end
-```
-
-1. At a minimum, you must provide an implementation for the hear method.  
-
-**MyExtensionListener.m**
-
-```text
-#import "MyExtensionListener.h"
-#import "MyExtension.h"
-
-@implementation MyExtensionListener 
-    - (void) hear:(ACPExtensionEvent *)event {
-        MyExtension* parentExtension = [self getParentExtension];
-        if (parentExtension == nil) {
-            NSLog(@"The parent extension was nil, skipping event");
-            return;
-        }
-
-        [parentExtension handleEvent:event];
-}
-
-/**
- * Returns the parent extension that owns this listener
- */
-- (MyExtension*) getParentExtension {
-    MyExtension* parentExtension = nil;
-    if ([[self extension] isKindOfClass:MyExtension.class]) {
-        parentExtension = (MyExtension*) [self extension];
-    }
-
-    return parentExtension;
-}
-
-@end
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ### **Android**
 
@@ -166,7 +117,66 @@ public class MyExtension extends Extension {
 }
 ```
 
-## What can you do in your event handler?
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+### **iOS**
+
+1. In Xcode create a new file from the `Cocoa Touch Class` template and save it in your project.
+2. Name your class `MyExtensionListener`, and it should be a subclass to the `ACPExtensionListener` class.
+
+   The `MyExtensionListener.m` file will contain your extension interface declaration and will import `ACPExtensionListener.h`. In the example below, the methods that are available for overriding are also displayed:
+
+**MyExtensionListener.h**
+
+```objective-c
+#import <ACPCore_iOS/ACPExtensionListener.h>
+#import <ACPCore_iOS/ACPExtensionEvent.h>
+
+@interface MyExtensionListener : ACPExtensionListener
+    - (void) hear:(ACPExtensionEvent *)event;
+@end
+```
+
+1. At a minimum, you must provide an implementation for the hear method.  
+
+**MyExtensionListener.m**
+
+```objective-c
+#import "MyExtensionListener.h"
+#import "MyExtension.h"
+
+@implementation MyExtensionListener 
+    - (void) hear:(ACPExtensionEvent *)event {
+        MyExtension* parentExtension = [self getParentExtension];
+        if (parentExtension == nil) {
+            NSLog(@"The parent extension was nil, skipping event");
+            return;
+        }
+
+        [parentExtension handleEvent:event];
+}
+
+/**
+ * Returns the parent extension that owns this listener
+ */
+- (MyExtension*) getParentExtension {
+    MyExtension* parentExtension = nil;
+    if ([[self extension] isKindOfClass:MyExtension.class]) {
+        parentExtension = (MyExtension*) [self extension];
+    }
+
+    return parentExtension;
+}
+
+@end
+```
+
+{% endtab %}
+{% endtabs %}
+
+### What can you do in your event handler?
 
 Your listener has a reference to the parent extension that registered it. You can use this to centralize logic into your extension class and call into it from your listener. This also means you have access to the extension services API \(`ACPExtensionApi` on iOS and `ExtensionApi` on Android\) provided to the extension. This will allow you to manage your shared states or register additional listeners. You also have access to the core SDK \(`ACPCore`\(iOS\) or `MobileCore` \(Android\). This will allow you to dispatch events and receive responses.
 
@@ -175,6 +185,53 @@ Your listener has a reference to the parent extension that registered it. You ca
 You can register your listener class by using the init method as in the example below. In the `hear` method, you can access the registered extensions instance by using the extension property. This step can be useful to maintain state in your extension or when you need to access to the `ACPExtensionApi` interface that the extension can also access.
 
 The following example calls the listeners hear method when a change to the Adobe Experience Platform SDKs configuration occurs.
+
+{% tabs %}
+{% tab title="Android" %}
+
+### **Android**
+
+Event listeners in Android are registered using the `registerEventListener` method of the `ExtensionApi` interface. You can access this interface by using the `getApi` method in `Extension`. This example show registering the listener from your extension contructor.
+
+```java
+import com.adobe.marketing.mobile.Extension;
+import com.adobe.marketing.mobile.ExtensionApi;
+
+public class MyExtension extends Extension {
+
+    public MyExtension(final ExtensionApi moduleApi) {
+        super(moduleApi);
+
+        ExtensionErrorCallback<ExtensionError> errorCallback = new ExtensionErrorCallback<ExtensionError>() {
+            @Override
+            public void error(final ExtensionError extensionError) {
+                // something went wrong, the listener couldn't be registered
+            }
+        };
+        getApi().registerEventListener("com.adobe.eventType.hub",
+                "com.adobe.eventSource.sharedState", MyListener.class, errorCallback);
+    }
+
+    @Override
+    public final String getName() {
+        return "my.company";
+    }
+
+    @Override
+    public final String getVersion() {
+        return "1.0.0";
+    }
+
+    @Override
+    public final void onUnregistered() {
+        // extension unregistered successfully - perform cleanup
+    }
+}
+```
+
+{% endtab %}
+
+{% tab title="Objective-C" %}
 
 ### **iOS**
 
@@ -195,7 +252,7 @@ In iOS the event listeners are registered using the `registerListener` method of
 
 **MyExtension.m**
 
-```text
+```objective-c
 #import "MyExtension.h"
 #import "MyExtensionListener.h"
 
@@ -238,74 +295,21 @@ In iOS the event listeners are registered using the `registerListener` method of
 @end
 ```
 
-### **Android**
-
-Event listeners in Android are registered using the `registerEventListener` method of the `ExtensionApi` interface. You can access this interface by using the `getApi` method in `Extension`. This example show registering the listener from your extension contructor.
-
-```java
-import com.adobe.marketing.mobile.Extension;
-import com.adobe.marketing.mobile.ExtensionApi;
-
-public class MyExtension extends Extension {
-
-    public MyExtension(final ExtensionApi moduleApi) {
-        super(moduleApi);
-
-        ExtensionErrorCallback<ExtensionError> errorCallback = new ExtensionErrorCallback<ExtensionError>() {
-            @Override
-            public void error(final ExtensionError extensionError) {
-                // something went wrong, the listener couldn't be registered
-            }
-        };
-        getApi().registerEventListener("com.adobe.eventType.hub",
-                "com.adobe.eventSource.sharedState", MyListener.class, errorCallback);
-    }
-
-    @Override
-    public final String getName() {
-        return "my.company";
-    }
-
-    @Override
-    public final String getVersion() {
-        return "1.0.0";
-    }
-
-    @Override
-    public final void onUnregistered() {
-        // extension unregistered successfully - perform cleanup
-    }
-}
-```
+{% endtab %}
+{% endtabs %}
 
 ## Registering a Wildcard Listener
 
 If you need to listen for all the events received and broadcasted by the Event Hub, you can register a wildcard listener by using the `registerWildcardListener` API.
 
+{% hint style="warning" %}
+
 **Important**: The `hear` method of this listener can be called often, and you should not do intensive processing on the same thread. We strongly recommended that you use your own thread executor for any processing that you do in this listener. This way, the Event Hub is not blocked, and the listener is not unregistered if it takes too long.
 
-### **iOS**
+{% endhint %}
 
-```text
-#import "MyExtension.h"
-#import "MyExtensionWildcardListener.h"
-
-@implementation MyExtension
-
--(instancetype) init {
-    if (self = [super init]) {        
-        NSError* error = nil;
-        if ([[self api] registerWildcardListener:[MyExtensionWildcardListener class] 
-                                             error:&error]) {
-            NSLog(@"MyExtensionWildcardListener successfully registered");
-        } else if (error) {
-            NSLog(@"An error occurred while registering MyExtensionWildcardListener, error code: %ld", [error code]);
-        }
-    }
-
-    return self;
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ### **Android**
 
@@ -330,3 +334,32 @@ public class MyExtension extends Extension {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+### **iOS**
+
+```objective-c
+#import "MyExtension.h"
+#import "MyExtensionWildcardListener.h"
+
+@implementation MyExtension
+
+-(instancetype) init {
+    if (self = [super init]) {        
+        NSError* error = nil;
+        if ([[self api] registerWildcardListener:[MyExtensionWildcardListener class] 
+                                             error:&error]) {
+            NSLog(@"MyExtensionWildcardListener successfully registered");
+        } else if (error) {
+            NSLog(@"An error occurred while registering MyExtensionWildcardListener, error code: %ld", [error code]);
+        }
+    }
+
+    return self;
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/event-listeners.md
+++ b/resources/building-mobile-extensions/event-listeners.md
@@ -123,7 +123,7 @@ public class MyExtension extends Extension {
 
 ### **iOS**
 
-1. In Xcode create a new file from the `Cocoa Touch Class` template and save it in your project.
+1. In Xcode, create a new file from the `Cocoa Touch Class` template and save it in your project.
 2. Name your class `MyExtensionListener`, and it should be a subclass to the `ACPExtensionListener` class.
 
    The `MyExtensionListener.m` file will contain your extension interface declaration and will import `ACPExtensionListener.h`. In the example below, the methods that are available for overriding are also displayed:
@@ -191,7 +191,7 @@ The following example calls the listeners hear method when a change to the Adobe
 
 ### **Android**
 
-Event listeners in Android are registered using the `registerEventListener` method of the `ExtensionApi` interface. You can access this interface by using the `getApi` method in `Extension`. This example show registering the listener from your extension contructor.
+Event listeners in Android are registered using the `registerEventListener` method of the `ExtensionApi` interface. You can access this interface by using the `getApi` method in `Extension`. The following example shows how to register the listener from your extension constructor.
 
 ```java
 import com.adobe.marketing.mobile.Extension;
@@ -300,7 +300,7 @@ In iOS the event listeners are registered using the `registerListener` method of
 
 ## Registering a Wildcard Listener
 
-If you need to listen for all the events received and broadcasted by the Event Hub, you can register a wildcard listener by using the `registerWildcardListener` API.
+To listen for all events that are received and broadcasted by the Event Hub, you can register a wildcard listener by using the `registerWildcardListener` API.
 
 {% hint style="warning" %}
 

--- a/resources/building-mobile-extensions/monitoring-shared-states.md
+++ b/resources/building-mobile-extensions/monitoring-shared-states.md
@@ -4,32 +4,8 @@ To monitor changes to a shared state, register an event listener by using `regis
 
 In the example below, you can find the listener that is being registered in the extension’s `init` method and the listener implementation where the shared state check is happening. The extension is checking for changes to the `com.adobe.module.configuration` shared state.
 
-## iOS
-
-### **MyExtension.m**
-
-```text
-- (instancetype) init {
-    NSError* error = nil;
-    if ([self.api registerListener: [MyExtensionListener class] eventType:@"com.adobe.eventType.hub" eventSource:@"com.adobe.eventSource.sharedState" error:&error]) {  
-        NSLog(@"MyExtensionListener was registered");
-   } else if (error) {  
-           NSLog(@"An error occured while registering MyExtensionListener: %ld", [error code]);
-    }
-}
-```
-
-### MyExtensionListener.m
-
-```text
-- (void) hear:(ACPExtensionEvent *)event {
-    NSDictionary* eventDataDict = event.eventData;
-    NSString* stateowner = [eventDataDict objectForKey:@"stateowner"];
-    if (stateowner && [stateowner isEqualToString:@"com.adobe.module.configuration"]) {  
-        // do something with the updated configuration information
-      }
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ## Android
 
@@ -66,3 +42,36 @@ public void hear(final Event event) {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+## iOS
+
+### **MyExtension.m**
+
+```objective-c
+- (instancetype) init {
+    NSError* error = nil;
+    if ([self.api registerListener: [MyExtensionListener class] eventType:@"com.adobe.eventType.hub" eventSource:@"com.adobe.eventSource.sharedState" error:&error]) {  
+        NSLog(@"MyExtensionListener was registered");
+   } else if (error) {  
+           NSLog(@"An error occured while registering MyExtensionListener: %ld", [error code]);
+    }
+}
+```
+
+### MyExtensionListener.m
+
+```objective-c
+- (void) hear:(ACPExtensionEvent *)event {
+    NSDictionary* eventDataDict = event.eventData;
+    NSString* stateowner = [eventDataDict objectForKey:@"stateowner"];
+    if (stateowner && [stateowner isEqualToString:@"com.adobe.module.configuration"]) {  
+        // do something with the updated configuration information
+      }
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/requesting-a-shared-state-that-is-not-tied-to-an-event.md
+++ b/resources/building-mobile-extensions/requesting-a-shared-state-that-is-not-tied-to-an-event.md
@@ -4,17 +4,8 @@ Here, extensions can skip passing the `ACPExtensionEvent` \(iOS\) / `Event` \(An
 
 **Tip:** The caller must be careful to account for null values being passed back.
 
-## iOS
-
-```text
-- (void) onUnregister {
-    NSError* error = nil;
-    NSDictionary* configurationSharedState = [self.api getSharedEventState:@"com.adobe.module.configuration" event:nil error:&error];
-    if (configurationSharedState) {
-        NSLog(@"The configuration when onUnregister was called was \n:%@", configurationSharedState);
-    }
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ## Android
 
@@ -34,3 +25,21 @@ public void onUnregistered() {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+## iOS
+
+```text
+- (void) onUnregister {
+    NSError* error = nil;
+    NSDictionary* configurationSharedState = [self.api getSharedEventState:@"com.adobe.module.configuration" event:nil error:&error];
+    if (configurationSharedState) {
+        NSLog(@"The configuration when onUnregister was called was \n:%@", configurationSharedState);
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/requesting-a-shared-state.md
+++ b/resources/building-mobile-extensions/requesting-a-shared-state.md
@@ -4,17 +4,8 @@ Extensions request shared states by using the `ACPExtensionApi` \(iOS\) / `Exten
 
 The example below shows a typical scenario where shared state is requested. In this scenario, a previously registered event listener is called, and the implementation gets the latest configuration shared state passing the current event as context.
 
-### iOS
-
-```text
-- (void) hear: (ACPExtensionEvent*) event {
-    NSError* error = nil;
-    NSDictionary* configurationSharedState = [[[self extension] api] getSharedEventState:@"com.adobe.module.configuration" event:event error:&error];
-    if (configurationSharedState) {
-        NSLog(@"The configuration when event \"%@\" was sent was:\n%@", event.eventName, configurationSharedState);
-    }
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ### Android
 
@@ -33,6 +24,25 @@ public void hear(final Event event) {
     ...
 }
 ```
+
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+### iOS
+
+```objective-c
+- (void) hear: (ACPExtensionEvent*) event {
+    NSError* error = nil;
+    NSDictionary* configurationSharedState = [[[self extension] api] getSharedEventState:@"com.adobe.module.configuration" event:event error:&error];
+    if (configurationSharedState) {
+        NSLog(@"The configuration when event \"%@\" was sent was:\n%@", event.eventName, configurationSharedState);
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## Public Shared State Constants
 

--- a/resources/building-mobile-extensions/requesting-a-shared-state.md
+++ b/resources/building-mobile-extensions/requesting-a-shared-state.md
@@ -2,7 +2,7 @@
 
 Extensions request shared states by using the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\) interface that is available in the `ACPExtension` \(iOS\) / `Extension` \(Android\) parent class. Extensions can request any of the publicly documented shared states, noting any prerequisites on timing. Generally, a shared state request occurs when an event listener, and the event that was heard, are passed when responding to an event listener callback. This ensures that the state you get back is synchronized with other events in flight at the same time. When your extension dispatches its own events or updates its shared data in response to an event, this synchronization is becomes extremely important.
 
-The example below shows a typical scenario where shared state is requested. In this scenario, a previously registered event listener is called, and the implementation gets the latest configuration shared state passing the current event as context.
+The example below shows a typical scenario where shared state is requested. In this scenario, a previously registered event listener is called, and the implementation gets the latest configuration shared state by passing the current event as context.
 
 {% tabs %}
 {% tab title="Android" %}

--- a/resources/building-mobile-extensions/updating-a-shared-state-that-is-not-tied-to-an-event.md
+++ b/resources/building-mobile-extensions/updating-a-shared-state-that-is-not-tied-to-an-event.md
@@ -2,27 +2,8 @@
 
 Here, extensions can skip passing the `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) parameter to the `setSharedEventState` method. The Adobe Cloud Platform SDKs will set the state to be the latest available state for this extension. This process ensures that new events will see this state, but events that are already in flight will have access to the older state if necessary.
 
-## iOS
-
-In the following example, the extension is setting a default state in the `init` method.
-
-```text
-- (nullable instancetype) init {
-    // construct data to be shared in a JSON format
-    NSDictionary* newEventData =
-    @{@"customData":@{
-              @"customElement":@{
-                      @"customInt":@125,
-                      @"customString":@"example"
-                      }
-              }};
-    NSError* error = nil;
-    if (![self.api setSharedEventState:newEventData event:nil error:&error] && error) {
-        NSLog(@"Error setting default shared state %@:%ld", [error domain], [error code]);
-    }
-    ...
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ## Android
 
@@ -50,3 +31,31 @@ MyExtension(final ExtensionApi extensionApi) {
     }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+## iOS
+
+In the following example, the extension is setting a default state in the `init` method.
+
+```objective-c
+- (nullable instancetype) init {
+    // construct data to be shared in a JSON format
+    NSDictionary* newEventData =
+    @{@"customData":@{
+              @"customElement":@{
+                      @"customInt":@125,
+                      @"customString":@"example"
+                      }
+              }};
+    NSError* error = nil;
+    if (![self.api setSharedEventState:newEventData event:nil error:&error] && error) {
+        NSLog(@"Error setting default shared state %@:%ld", [error domain], [error code]);
+    }
+    ...
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/updating-a-shared-state-that-is-not-tied-to-an-event.md
+++ b/resources/building-mobile-extensions/updating-a-shared-state-that-is-not-tied-to-an-event.md
@@ -1,6 +1,6 @@
 # Updating a shared state that is not tied to an event
 
-Here, extensions can skip passing the `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) parameter to the `setSharedEventState` method. The Adobe Cloud Platform SDKs will set the state to be the latest available state for this extension. This process ensures that new events will see this state, but events that are already in flight will have access to the older state if necessary.
+Here, extensions can skip passing the `ACPExtensionEvent` \(iOS\) / `Event` \(Android\) parameter to the `setSharedEventState` method. The Adobe Experience Platform SDKs set the state to be the latest available state for this extension. This process ensures that new events will see this state, but events that are already in flight will have access to the older state if necessary.
 
 {% tabs %}
 {% tab title="Android" %}

--- a/resources/building-mobile-extensions/updating-the-shared-state.md
+++ b/resources/building-mobile-extensions/updating-the-shared-state.md
@@ -2,24 +2,8 @@
 
 Extensions set a shared state by creating an event data that the extensions want to save and by calling `setSharedEventState` from the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\) interface that is available through the `ACPExtension` \(iOS\) / `Extension` \(Android\) parent class. Extensions can only set their own state, so the name that is used is the same as your extension \(for example, _com.exampleCompany.extension_\). This name is also the name that other extensions need to use when requesting your shared state.
 
-## iOS
-
-```text
-- (void) hear: (nonnull ACPExtensionEvent*) event {
-    // construct the data to be shared in a JSON format
-    NSDictionary* newEventData =
-    @{@"customData":@{
-              @"customElement":@{
-                      @"customInt":@125,
-                      @"customString":@"example"
-                      }
-              }};
-    NSError* error = nil;
-    if (![self.extension.api setSharedEventState:newEventData event:event error:&error] && error) {
-        NSLog(@"Error setting shared state %@:%ld", [error domain], [error code]);
-    }
-}
-```
+{% tabs %}
+{% tab title="Android" %}
 
 ## Android
 
@@ -45,3 +29,28 @@ public void hear(final Event event) {
 }
 ```
 
+{% endtab %}
+
+{% tab title="Objective-C" %}
+
+## iOS
+
+```objective-c
+- (void) hear: (nonnull ACPExtensionEvent*) event {
+    // construct the data to be shared in a JSON format
+    NSDictionary* newEventData =
+    @{@"customData":@{
+              @"customElement":@{
+                      @"customInt":@125,
+                      @"customString":@"example"
+                      }
+              }};
+    NSError* error = nil;
+    if (![self.extension.api setSharedEventState:newEventData event:event error:&error] && error) {
+        NSLog(@"Error setting shared state %@:%ld", [error domain], [error code]);
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}

--- a/resources/building-mobile-extensions/updating-the-shared-state.md
+++ b/resources/building-mobile-extensions/updating-the-shared-state.md
@@ -1,6 +1,6 @@
 # Updating the shared state
 
-Extensions set a shared state by creating an event data that the extensions want to save and by calling `setSharedEventState` from the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\) interface that is available through the `ACPExtension` \(iOS\) / `Extension` \(Android\) parent class. Extensions can only set their own state, so the name that is used is the same as your extension \(for example, _com.exampleCompany.extension_\). This name is also the name that other extensions need to use when requesting your shared state.
+Extensions set a shared state by creating an event data that the extensions save by calling `setSharedEventState` from the `ACPExtensionApi` \(iOS\) / `ExtensionApi` \(Android\) interface. This interface is available through the `ACPExtension` \(iOS\) / `Extension` \(Android\) parent class. Extensions can only set their own state, so the name that is used is the same as your extension \(for example, _com.exampleCompany.extension_\). This name is also the name that other extensions need to use when requesting your shared state.
 
 {% tabs %}
 {% tab title="Android" %}

--- a/using-mobile-extensions/mobile-core/configuration-reference/rules-engine-reference.md
+++ b/using-mobile-extensions/mobile-core/configuration-reference/rules-engine-reference.md
@@ -19,7 +19,7 @@ Rules and their associated assets will be delivered as a standard ZIP archive, w
 
 ## File Delivery
 
-Delivery will happen by using a request from the Adobe Cloud Platform SDKs to a list of static endpoints that are defined as part of the SDK configuration. The SDK supports token expansions on this endpoint, which allows the injection of ECIDs and property IDs into the request.
+Delivery will happen by using a request from the Adobe Experience Platform SDKs to a list of static endpoints that are defined as part of the SDK configuration. The SDK supports token expansions on this endpoint, which allows the injection of ECIDs and property IDs into the request.
 
 This request is a conditional `GET` and occurs by default at the start of each new session.
 
@@ -112,7 +112,7 @@ To avoid collisions, special key prefixes always start with `~` to differentiate
 | ~type | ~type | Reads `eventType` from the triggering event. |
 | ~source | ~source | Reads `eventSource` from the triggering event. |
 | ~timestampu | ~timestampu | Reads the current device time in epoch format \(seconds since epoch\). |
-| ~sdkver | ~sdkver | Reads the current Adobe Cloud Platform SDKs version string. |
+| ~sdkver | ~sdkver | Reads the current Adobe Experience Platform SDKs version string. |
 | ~cachebust | ~cachebust | Generates a random number to be used for cache busting. |
 | ~all\_url | ~all\_url | Contains all data in the Event object and is encoded in the `url` format. |
 | ~all\_json | ~all\_json | Contains all data in the Event object that is encoded in the `json` format. |
@@ -386,7 +386,7 @@ Since the Rules Engine can support multiple end-point URLs from where to fetch r
 }
 ```
 
-The Adobe Cloud Platform SDKs process the URLs based on the order in which they are specified. Both endpoints are URLs that point to a zipped rules collection that contains a _rules.json_ file, an asset folder that contains images, and HTMLs that are used by the rules.
+The Adobe Experience Platform SDKs process the URLs based on the order in which they are specified. Both endpoints are URLs that point to a zipped rules collection that contains a _rules.json_ file, an asset folder that contains images, and HTMLs that are used by the rules.
 
 After downloading and extracting rules, the contents of this compressed file are stored in the cache. To trigger an update/download of the rules, see [Rules Engine Methods in Android](https://github.com/jiabingeng/sdk-v5-docs/tree/ece930399ffb1a7605b3aa13ed0e6633c8a8a481/rules-engine/rules-api-in-android.md) or [Rules Engine Methods in iOS](https://github.com/jiabingeng/sdk-v5-docs/tree/ece930399ffb1a7605b3aa13ed0e6633c8a8a481/rules-engine/rules-api-in-ios.md).
 

--- a/using-mobile-extensions/mobile-core/configuration-reference/rules-engine-reference.md
+++ b/using-mobile-extensions/mobile-core/configuration-reference/rules-engine-reference.md
@@ -19,9 +19,9 @@ Rules and their associated assets will be delivered as a standard ZIP archive, w
 
 ## File Delivery
 
-Delivery will happen by using a request from the Adobe Experience Platform SDKs to a list of static endpoints that are defined as part of the SDK configuration. The SDK supports token expansions on this endpoint, which allows the injection of ECIDs and property IDs into the request.
+File delivery occurs by using a request from the Adobe Experience Platform SDKs to a static endpoint that is defined as part of the SDK configuration. The SDKs support token expansions on this endpoint, which allows the injection of ECIDs and property IDs into the request.
 
-This request is a conditional `GET` and occurs by default at the start of each new session.
+This request is a conditional `GET` and occurs by default at the start of each new application session.
 
 ### rules.json format
 
@@ -89,7 +89,7 @@ A Group-type condition contains an array of conditions, which makes the conditio
 | :--- | :--- | :--- |
 | Equals | eq | string, number |
 | Not Equals | ne | string, number |
-| Exists | eq | string, number |
+| Exists | ex | no value required |
 | Not Exists | ne | string, number |
 | Greater Than | gt | number |
 | Greater Than or Equals | ge | number |


### PR DESCRIPTION
Changes:
- Updated extension registration error handling section in Android
- Added tabs in the Build your own extension section for ios/android code examples
- Renamed Adobe Cloud Platform SDK to Adobe Experience Platform SDK
