### PR TITLE
[AMSDK-7030] Remove vid from Identity

### DIFF
--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -169,9 +169,9 @@ Appends Adobe visitor data to a URL string. If the provided URL is null or empty
 * The `adobe_mc` attribute is an URL encoded list containing:
   * Experience Cloud ID \(ECID\)
   * Experience Cloud Org ID
-  * Analytics Tracking ID, if available from [Analytics](../../adobe-analytics/)
+  * Analytics Tracking ID (AID), if available from the [Analytics extension](../../adobe-analytics/)
   * A timestamp taken when this request was made
-* The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID, if available.
+* The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID (VID), if previously set in the [Analytics extension](../../adobe-analytics/analytics-api-reference#setidentifier).
 
 #### **Syntax**
 
@@ -206,9 +206,9 @@ If the provided URL is nil or empty, it is returned as is. Otherwise, the follow
 * The adobe\_mc attribute is an URL encoded list containing:
   * Experience Cloud ID \(ECID\)
   * Experience Cloud Org ID
-  * Analytics Tracking ID, if available from [Analytics](../../adobe-analytics/)
+  * Analytics Tracking ID (AID), if available from the [Analytics extension](../../adobe-analytics/)
   * A timestamp taken when this request was made
-* The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID, if available.
+* The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID (VID), if previously set in the [Analytics extension](../../adobe-analytics/analytics-api-reference#setidentifier).
 
 #### **Syntax**
 

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -169,6 +169,7 @@ Appends Adobe visitor data to a URL string. If the provided URL is null or empty
 * The `adobe_mc` attribute is an URL encoded list containing:
   * Experience Cloud ID \(ECID\)
   * Experience Cloud Org ID
+  * Analytics tracking ID, if available from [Analytics](../../adobe-analytics/)
   * A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID, if available.
 
@@ -205,6 +206,7 @@ If the provided URL is nil or empty, it is returned as is. Otherwise, the follow
 * The adobe\_mc attribute is an URL encoded list containing:
   * Experience Cloud ID \(ECID\)
   * Experience Cloud Org ID
+  * Analytics tracking ID, if available from [Analytics](../../adobe-analytics/)
   * A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID, if available.
 

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -169,7 +169,7 @@ Appends Adobe visitor data to a URL string. If the provided URL is null or empty
 * The `adobe_mc` attribute is an URL encoded list containing:
   * Experience Cloud ID \(ECID\)
   * Experience Cloud Org ID
-  * Analytics tracking ID, if available from [Analytics](../../adobe-analytics/)
+  * Analytics Tracking ID, if available from [Analytics](../../adobe-analytics/)
   * A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID, if available.
 
@@ -206,7 +206,7 @@ If the provided URL is nil or empty, it is returned as is. Otherwise, the follow
 * The adobe\_mc attribute is an URL encoded list containing:
   * Experience Cloud ID \(ECID\)
   * Experience Cloud Org ID
-  * Analytics tracking ID, if available from [Analytics](../../adobe-analytics/)
+  * Analytics Tracking ID, if available from [Analytics](../../adobe-analytics/)
   * A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID, if available.
 

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -167,10 +167,10 @@ ACPMobileVisitorAuthenticationState.authenticated)
 Appends Adobe visitor data to a URL string. If the provided URL is null or empty, it is returned as is. Otherwise, the following information is added to the URL string that is returned in the [AdobeCallback](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#adobecallback) instance:
 
 * The `adobe_mc` attribute is an URL encoded list containing:
-  * Experience Cloud ID \(ECID\)
-  * Experience Cloud Org ID
-  * Analytics Tracking ID (AID), if available from the [Analytics extension](../../adobe-analytics/)
-  * A timestamp taken when this request was made
+  * `MCMID` - Experience Cloud ID \(ECID\)
+  * `MCORGID` - Experience Cloud Org ID
+  * `MCAID` - Analytics Tracking ID (AID), if available from the [Analytics extension](../../adobe-analytics/)
+  * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID (VID), if previously set in the [Analytics extension](../../adobe-analytics/analytics-api-reference#setidentifier).
 
 #### **Syntax**
@@ -204,10 +204,10 @@ Appends Adobe visitor data to a URL.
 If the provided URL is nil or empty, it is returned as is. Otherwise, the following information is added to the url string that is returned via the callback:
 
 * The adobe\_mc attribute is an URL encoded list containing:
-  * Experience Cloud ID \(ECID\)
-  * Experience Cloud Org ID
-  * Analytics Tracking ID (AID), if available from the [Analytics extension](../../adobe-analytics/)
-  * A timestamp taken when this request was made
+  * `MCMID` - Experience Cloud ID \(ECID\)
+  * `MCORGID` - Experience Cloud Org ID
+  * `MCAID` - Analytics Tracking ID (AID), if available from the [Analytics extension](../../adobe-analytics/)
+  * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID (VID), if previously set in the [Analytics extension](../../adobe-analytics/analytics-api-reference#setidentifier).
 
 #### **Syntax**

--- a/using-mobile-extensions/mobile-core/identity/identity-event-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-event-reference.md
@@ -56,7 +56,6 @@ Here are the key-value pairs in this event:
 | **Key or Key Type** | **Value Type** | **Optional** | **Description** |
 | :--- | :--- | :--- | :--- |
 | `mid (String)` | String | false | Auto Generated MID |
-| `vid (String)` | String | false | Blank if not present |
 | `advertisingIdentifier (String)` | String | false | Blank if not present |
 | `pushIdentifier (String)` | String | false | Blank if not present |
 | `blob (String)` | String | false | Blank if not present |

--- a/using-mobile-extensions/mobile-core/identity/identity-event-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-event-reference.md
@@ -63,3 +63,7 @@ Here are the key-value pairs in this event:
 | `visitorIDsList (String)` | List | false | Default: Empty List |
 | `lastSync (String)` | Long | false | default = 0 |
 
+{% hint style="warning" %}
+The Analytics Custom Visitor ID (VID) is no longer included in the data payload. If needed, it may be retrieved from the [Analytics extension](../../adobe-analytics/analytics-api-reference#get-the-custom-visitor-identifier).
+{% endhint %}
+


### PR DESCRIPTION
Clean up work for the Identity Extension core code.

- Remove reference to `vid` in Identity shared state, as it wasn't being set previously and is now removed from the code
- List Analytics Tracking ID as being set in appendToUrl/appendVisitorInfoForUrl

