### PR TITLE
Update to release notes for iOS 2.2.2 and Android 1.3.1

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -10,6 +10,7 @@ The following updates were made in this release:
 * Added support for ISO 8601 timestamp for Rules Engine token replacement, you can use the placeholder `~timestampz` 
 * Fixed the bug where `ACPCore.getSdkIdentities` didn't return the correct value for Analytics visitor identifier \(VID\).
 * Added support for migrating Privacy status from v4 to v5, if it was manually set with v4 SDK.
+* Fixed issue where retrieving Privacy status may get delayed when device is offline.
 
 #### iOS Identity 2.0.3:
 
@@ -22,6 +23,7 @@ The following updates were made in this release:
 * Added support for ISO 8601 timestamp for Rules Engine token replacement, you can use the placeholder `~timestampz`
 * Fixed the bug where `MobileCore.getSdkIdentities` didn't return the correct value for Analytics visitor identifier \(VID\).
 * Added support for migrating Privacy status from v4 to v5, if it was manually set with v4 SDK.
+* Fixed issue where retrieving Privacy status may get delayed when device is offline.
 * Added support for loading cached configuraiton and cached rules on subsequent launch.
 
 #### Android Identity 1.0.5:


### PR DESCRIPTION
update release notes for iOS 2.2.2 Andorid 1.3.1 with fix for getPrivacyStatus when device is offline