### PR TITLE
Add Identity getUrlVariables API reference for React Native platform

### DIFF
--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -71,6 +71,7 @@ Here is the code sample to register the Identity extension:
 
 {% tabs %}
 {% tab title="Android" %}
+
 ### Java
 
 After calling the `setApplication()` method in the `onCreate()` method, register the extension.
@@ -135,4 +136,124 @@ Previously known as MCID, the Experience Cloud ID or ECID uniquely identifies ea
 {% endhint %}
 
 After the configuration is complete, an Experience Cloud ID is generated and, where applicable, is included on all Analytics and Audience Manager hits. Other IDs, such as custom and automatically-generated IDs, continue to be sent with each hit.
+
+## Visitor Tracking between an App and Mobile Web
+
+If you app opens mobile web content, you need to ensure that visitors are not identified separately as they move between the native and mobile web.
+
+#### Visitor IDs in Apps
+
+The Mobile SDK generates a unique visitor ID (ECID) when the app is installed. The ECID is stored in persistent memory on the mobile device and is sent with every hit. The ECID is removed when the user uninstalles the app or if the user sets the Mobile SDK global privacy status to Opt-Out.
+
+{% hint style="info" %}
+
+When the Mobile SDK privacy status is set to Opt-Out and the ECID is removed, a new unique visitor ID (ECID) is generated when the user sets the global privacy status to Opt-In.
+
+{% endhint %}
+
+{% hint style="info" %}
+
+App visitor IDs persist through upgrades.
+
+{% endhint %}
+
+#### Visitor IDs in the Mobile Web
+
+Typical mobile web implementations use the same standard Analytics `s_code.js` or `AppMeasurement.js` that is used within desktop sites. The JavaScript libraries have their own methods of generating unique visitor IDs, which causes a different vistior ID to be generated when you open mobile web content from your app.
+
+To use the same visitor ID in the app and mobile web, complete the following instructions to pass the visitor ID to the mobile web in the URL.
+
+##### Implementing Visitor Tracking between an App and Mobile Web
+
+{% tabs %}
+{% tab title="Android" %}
+
+### Java
+
+To append visitor information to the URL that is being used to open the web view, call [appendVisitorInfoForUrl](./identity-api-reference#appendtourl-java):
+
+```java
+Identity.appendVisitorInfoForURL("http://myurl.com", new AdobeCallback<String>() {    
+    @Override    
+    public void call(String urlWithAdobeVisitorInfo) {        
+        //handle the new URL here        
+        //For example, open the URL on the device browser        
+        //        
+        Intent i = new Intent(Intent.ACTION_VIEW);        
+        i.setData(Uri.parse(urlWithAdobeVisitorInfo));        
+        startActivity(i);    
+    }
+});
+```
+
+Alternately, starting with SDK version 1.4.0, you can call [getUrlVariables](./identity-api-reference#geturlvariables-java) and build your own URL:
+
+```java
+Identity.getUrlVariables(new AdobeCallback<String>() {    
+    @Override    
+    public void call(String stringWithAdobeVisitorInfo) {        
+        //handle the URL query parameter string here 
+        //For example, open the URL on the device browser        
+        //        
+        Intent i = new Intent(Intent.ACTION_VIEW);        
+        i.setData(Uri.parse("http://myUrl.com?" + urlWithAdobeVisitorInfo));        
+        startActivity(i);    
+    }
+});
+```
+
+{% endtab %}
+
+{% tab title="iOS" %}
+
+### Objective-C
+
+To append visitor information to the URL that is being used to open the web view, call [appendToUrl](./identity-api-reference#appendtourl-ios):
+
+```objective-c
+NSURL* url = [[NSURL alloc] initWithString:@"www.myUrl.com"];
+[ACPIdentity appendToUrl:url withCallback:^(NSURL * _Nullable urlWithVisitorData) {    
+// handle the appended url here}
+}];
+```
+
+Alternately, starting with SDK version 2.3.0, you can call [getUrlVariables](./identity-api-reference#geturlvariables-ios) and build your own URL:
+
+```objective-c
+[ACPIdentity getUrlVariables:^(NSString * _Nullable urlVariables) {    
+  // handle the URL query parameter string here
+  NSString* urlString = @"http://myUrl.com";
+  NSString* urlStringWithVisitorData = [NSString stringWithFormat:@"%@?%@", urlString, urlVariables];
+  NSURL* urlWithVisitorData = [NSURL URLWithString:urlStringWithVisitorData];
+  [[UIApplication sharedApplication] openURL:urlWithVisitorData options:@{} completionHandler:^(BOOL success) {
+    // handle openURL success
+  }];
+}];
+```
+
+{% endtab %}
+
+{% tab title="React Native" %}
+
+### JavaScript
+
+To append visitor information to the URL that is being used to open the web view, call [appendVisitorInfoForUrl](./identity-api-reference#appendtourl-js):
+
+```java
+ACPIdentity.appendVisitorInfoForURL("www.myUrl.com").then(urlWithVistorData => console.log("AdobeExperenceSDK: Url with Visitor Data = " + urlWithVisitorData));
+```
+
+Alternately, starting with SDK version 1.0.5, you can call [getUrlVariables](./identity-api-reference#geturlvariables-js) and build your own URL:
+
+```java
+ACPIdentity.getUrlVariables().then(urlVariables => console.log("AdobeExperenceSDK: query params = " + urlVariables));
+```
+
+{% endtab %}
+
+{% endtabs %}
+
+The ID service code on the destination domain extracts the ECID from the URL instead of sending a request to Adobe for a new ID. The ID service code on the destination page used the passed-in ECID to track the visitor.
+
+On hits from the mobile web content, verify that the `mid` parameter is present on each hit, and that this value matches the `mid` that is being sent by the app code.
 

--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -210,7 +210,7 @@ Identity.getUrlVariables(new AdobeCallback<String>() {
 
 To append visitor information to the URL that is being used to open the web view, call [appendToUrl](./identity-api-reference#appendtourl-ios):
 
-```objective-c
+```objectivec
 NSURL* url = [[NSURL alloc] initWithString:@"www.myUrl.com"];
 [ACPIdentity appendToUrl:url withCallback:^(NSURL * _Nullable urlWithVisitorData) {    
 // handle the appended url here
@@ -219,7 +219,7 @@ NSURL* url = [[NSURL alloc] initWithString:@"www.myUrl.com"];
 
 Alternately, starting with SDK version 2.3.0 (ACPIdentity version 2.1.0), you can call [getUrlVariables](./identity-api-reference#geturlvariables-ios) and build your own URL:
 
-```objective-c
+```objectivec
 [ACPIdentity getUrlVariables:^(NSString * _Nullable urlVariables) {    
   // handle the URL query parameter string here
   NSString* urlString = @"http://myUrl.com";

--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -132,7 +132,7 @@ initSDK() {
 {% endtabs %}
 
 {% hint style="info" %}
-Previously known as MCID, the Experience Cloud ID or ECID uniquely identifies each client company in the Adobe Experience Cloud and is similar to the following value:`016D5C175213CCA80A490D05@AdobeOrg`. The trailing `@AdobeOrg` is required.
+Previously known as MCID, the Experience Cloud ID or ECID uniquely identifies each visitor in the Adobe Experience Cloud and is similar to the following value:`65002602839283012066007008864929833047`.
 {% endhint %}
 
 After the configuration is complete, an Experience Cloud ID is generated and, where applicable, is included on all Analytics and Audience Manager hits. Other IDs, such as custom and automatically-generated IDs, continue to be sent with each hit.
@@ -143,7 +143,7 @@ If you app opens mobile web content, you need to ensure that visitors are not id
 
 #### Visitor IDs in Apps
 
-The Mobile SDK generates a unique visitor ID (ECID) when the app is installed. The ECID is stored in persistent memory on the mobile device and is sent with every hit. The ECID is removed when the user uninstalles the app or if the user sets the Mobile SDK global privacy status to Opt-Out.
+The Mobile SDK generates a unique visitor ID when the app is installed. This Experience Cloud ID (ECID, previously known as MCID) is stored in persistent memory on the mobile device and is sent with every hit. The ECID is removed when the user uninstalles the app or if the user sets the Mobile SDK global privacy status to Opt-Out.
 
 {% hint style="info" %}
 

--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -132,7 +132,7 @@ initSDK() {
 {% endtabs %}
 
 {% hint style="info" %}
-Previously known as MCID, the Experience Cloud ID or ECID uniquely identifies each visitor in the Adobe Experience Cloud and is a 32 character length ID.
+Previously known as MCID, the Experience Cloud ID (ECID) uniquely identifies each visitor in the Adobe Experience Cloud and is a 32-character ID.
 {% endhint %}
 
 After the configuration is complete, an Experience Cloud ID is generated and, where applicable, is included on all Analytics and Audience Manager hits. Other IDs, such as custom and automatically-generated IDs, continue to be sent with each hit.
@@ -213,7 +213,7 @@ To append visitor information to the URL that is being used to open the web view
 ```objective-c
 NSURL* url = [[NSURL alloc] initWithString:@"www.myUrl.com"];
 [ACPIdentity appendToUrl:url withCallback:^(NSURL * _Nullable urlWithVisitorData) {    
-// handle the appended url here}
+// handle the appended url here
 }];
 ```
 

--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -132,7 +132,7 @@ initSDK() {
 {% endtabs %}
 
 {% hint style="info" %}
-Previously known as MCID, the Experience Cloud ID or ECID uniquely identifies each visitor in the Adobe Experience Cloud and is similar to the following value:`65002602839283012066007008864929833047`.
+Previously known as MCID, the Experience Cloud ID or ECID uniquely identifies each visitor in the Adobe Experience Cloud and is a 32 character length ID.
 {% endhint %}
 
 After the configuration is complete, an Experience Cloud ID is generated and, where applicable, is included on all Analytics and Audience Manager hits. Other IDs, such as custom and automatically-generated IDs, continue to be sent with each hit.
@@ -186,7 +186,7 @@ Identity.appendVisitorInfoForURL("http://myurl.com", new AdobeCallback<String>()
 });
 ```
 
-Alternately, starting with SDK version 1.4.0, you can call [getUrlVariables](./identity-api-reference#geturlvariables-java) and build your own URL:
+Alternately, starting with SDK version 1.4.0 (Identity version 1.1.0), you can call [getUrlVariables](./identity-api-reference#geturlvariables-java) and build your own URL:
 
 ```java
 Identity.getUrlVariables(new AdobeCallback<String>() {    
@@ -217,7 +217,7 @@ NSURL* url = [[NSURL alloc] initWithString:@"www.myUrl.com"];
 }];
 ```
 
-Alternately, starting with SDK version 2.3.0, you can call [getUrlVariables](./identity-api-reference#geturlvariables-ios) and build your own URL:
+Alternately, starting with SDK version 2.3.0 (ACPIdentity version 2.1.0), you can call [getUrlVariables](./identity-api-reference#geturlvariables-ios) and build your own URL:
 
 ```objective-c
 [ACPIdentity getUrlVariables:^(NSString * _Nullable urlVariables) {    

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -379,6 +379,36 @@ ACPIdentity.getUrlVariables {(urlVariables) in
 }
 ```
 {% endtab %}
+{% tab title="React Native" %}
+
+#### JavaScript
+
+### getUrlVariables
+
+*added in react-native-acpcore v1.0.5*
+
+Retrieve Adobe visitor data as a URL query parameter string for consumption in hybrid mobile applications. There is no leading "?" or "&" punctuation, as the caller is responsible for placing the string in the correct location of their resulting URL. The following information is added to the string that is returned via the callback:
+
+- The adobe\_mc attribute is an URL encoded list containing:
+  - `MCMID` - Experience Cloud ID \(ECID\)
+  - `MCORGID` - Experience Cloud Org ID
+  - `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](../../adobe-analytics/)
+  - `TS` - A timestamp taken when this request was made
+- The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://github.com/Adobe-Marketing-Cloud/aep-sdks-documentation/tree/174e9069bc1d3a521b59d52a066e9a7730f60ff5/using-mobile-extensions/adobe-analytics/analytics-api-reference/README.md#setidentifier).
+
+#### Syntax
+
+```jsx
+ACPIdentity.getUrlVariables();
+```
+
+#### Usage
+
+```jsx
+ACPIdentity.getUrlVariables().then(urlVariables => console.log("AdobeExperenceSDK: query params = " + urlVariables));
+```
+
+{% endtab %}
 {% endtabs %}
 
 ## Get identifiers

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -194,11 +194,11 @@ const UNKNOWN = "ACP_VISITOR_AUTH_STATE_UNKNOWN";
 {% endtab %}
 {% endtabs %}
 
-## Append visitor data to a URL
+## Append visitor data to a URL <a id="appendToUrlTitle"></a>
 
 {% tabs %}
 {% tab title="Android" %}
-### appendVisitorInfoForURL
+### appendVisitorInfoForURL<a id="appendToUrl-java"></a>
 
 Appends Adobe visitor data to a URL string. If the provided URL is null or empty, it is returned as is. Otherwise, the following information is added to the URL string that is returned in the [AdobeCallback](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#adobecallback) instance:
 
@@ -233,7 +233,7 @@ Identity.appendVisitorInfoForURL("http://myurl.com", new AdobeCallback<String>()
 {% endtab %}
 
 {% tab title="iOS" %}
-### appendToURL
+### appendToURL<a id="appendToUrl-ios"></a>
 
 Appends Adobe visitor data to a URL.
 
@@ -276,15 +276,23 @@ ACPIdentity.append(to:URL(string: "www.myUrl.com"), withCallback: {(appendedURL)
 {% tab title="React Native" %}
 #### JavaScript
 
-### appendToURL
+### appendVisitorInfoForURL<a id="appendToUrl-js"></a>
 
 Appends Adobe visitor information to the given URL.
 
 If the given url is nil or empty, it is returned as is. Otherwise, the following information is added to the query section of the given URL. The attribute `adobe_mc` is an URL encoded list containing the Experience Cloud ID, Experience Cloud Org ID, and a timestamp when this request was made. The attribute `adobe_aa_vid` is the URL encoded Visitor ID, however the attribute is only included if the Visitor ID was previously set.
 
+#### Syntax
+
 ```jsx
 ACPIdentity.appendVisitorInfoForURL(baseURL);
 ```
+#### Example
+
+```jsx
+ACPIdentity.appendVisitorInfoForURL("www.myUrl.com").then(urlWithVistorData => console.log("AdobeExperenceSDK: Url with Visitor Data = " + urlWithVisitorData));
+```
+
 {% endtab %}
 {% endtabs %}
 
@@ -292,7 +300,7 @@ ACPIdentity.appendVisitorInfoForURL(baseURL);
 
 {% tabs %}
 {% tab title="Android" %}
-### getUrlVariables
+### getUrlVariables<a id="geturlvariables-java"></a>
 
 _added in Identity v1.1.0_
 
@@ -329,7 +337,7 @@ Identity.getUrlVariables(new AdobeCallback<String>() {
 {% endtab %}
 
 {% tab title="iOS" %}
-### getUrlVariables
+### getUrlVariables<a id="geturlvariables-ios"></a>
 
 _added in ACPIdentity v2.1.0_
 
@@ -383,7 +391,7 @@ ACPIdentity.getUrlVariables {(urlVariables) in
 
 #### JavaScript
 
-### getUrlVariables
+### getUrlVariables<a id="geturlvariables-js"></a>
 
 *added in react-native-acpcore v1.0.5*
 
@@ -402,7 +410,7 @@ Retrieve Adobe visitor data as a URL query parameter string for consumption in h
 ACPIdentity.getUrlVariables();
 ```
 
-#### Usage
+#### Example
 
 ```jsx
 ACPIdentity.getUrlVariables().then(urlVariables => console.log("AdobeExperenceSDK: query params = " + urlVariables));

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -302,7 +302,7 @@ ACPIdentity.appendVisitorInfoForURL("www.myUrl.com").then(urlWithVistorData => c
 {% tab title="Android" %}
 ### getUrlVariables<a id="geturlvariables-java"></a>
 
-_added in Identity v1.1.0_
+_added in sdk-core v1.4.0 (Identity v1.1.0)_
 
 Retrieve Adobe visitor data as a URL query parameter string for consumption in hybrid mobile applications. There is no leading "?" or "&" punctuation, as the caller is responsible for placing the string in the correct location of their resulting URL. The following information is added to the string that is returned in the [AdobeCallback](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#adobecallback) instance:
 
@@ -339,7 +339,7 @@ Identity.getUrlVariables(new AdobeCallback<String>() {
 {% tab title="iOS" %}
 ### getUrlVariables<a id="geturlvariables-ios"></a>
 
-_added in ACPIdentity v2.1.0_
+_added in ACPCore v2.3.0 (ACPIdentity v2.1.0)_
 
 Retrieve Adobe visitor data as a URL query parameter string for consumption in hybrid mobile applications. There is no leading "?" or "&" punctuation, as the caller is responsible for placing the string in the correct location of their resulting URL. The following information is added to the string that is returned via the callback:
 


### PR DESCRIPTION
Add API reference for Identity.getUrlVariables on React Native platform.
Add "Visitor Tracking Between an App and Mobile Web" section in Identity.