### PR TITLE
[AMSDK-8575] Clarify Identity.appendToURL API

### DIFF
--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -211,6 +211,14 @@ If the provided URL is null or empty, it is returned as is. Otherwise, the follo
   * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics).
 
+{% hint style="info" %}
+
+This API is designed to handle URL formats: `scheme://authority/path?query=param#fragment`. In this example, the Adobe visitor data is appended as `scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment`
+
+If your application uses more complicated URLs, such as angular URLs, we recommend using [getUrlVariables](#geturlvariables-java).
+
+{endhint}
+
 #### **Syntax**
 
 ```java
@@ -247,6 +255,14 @@ If the provided URL is nil or empty, it is returned as is. Otherwise, the follow
   * `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](../../adobe-analytics/)
   * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://github.com/Adobe-Marketing-Cloud/aep-sdks-documentation/tree/174e9069bc1d3a521b59d52a066e9a7730f60ff5/using-mobile-extensions/adobe-analytics/analytics-api-reference/README.md#setidentifier).
+
+{% hint style="info" %}
+
+This API is designed to handle URL formats: `scheme://authority/path?query=param#fragment`. In this example, the Adobe visitor data is appended as `scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment`
+
+If your application uses more complicated URLs, such as angular URLs, we recommend using [getUrlVariables](#geturlvariables-ios).
+
+{endhint}
 
 #### **Syntax**
 
@@ -290,6 +306,14 @@ If the given url is nil or empty, it is returned as is. Otherwise, the following
   - `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](../../adobe-analytics/)
   - `TS` - A timestamp taken when this request was made
 - The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://github.com/Adobe-Marketing-Cloud/aep-sdks-documentation/tree/174e9069bc1d3a521b59d52a066e9a7730f60ff5/using-mobile-extensions/adobe-analytics/analytics-api-reference/README.md#setidentifier).
+
+{% hint style="info" %}
+
+This API is designed to handle URL formats: `scheme://authority/path?query=param#fragment`. In this example, the Adobe visitor data is appended as `scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment`
+
+If your application uses more complicated URLs, such as angular URLs, we recommend using [getUrlVariables](#geturlvariables-js).
+
+{endhint}
 
 #### Syntax
 

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -200,9 +200,11 @@ const UNKNOWN = "ACP_VISITOR_AUTH_STATE_UNKNOWN";
 {% tab title="Android" %}
 ### appendVisitorInfoForURL <a id="appendToUrl-java"></a>
 
-Appends Adobe visitor data to a URL string. If the provided URL is null or empty, it is returned as is. Otherwise, the following information is added to the URL string that is returned in the [AdobeCallback](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#adobecallback) instance:
+Appends Adobe visitor data to the query component of the given URL.
 
-* The `adobe_mc` attribute is an URL encoded list that contains:
+If the provided URL is null or empty, it is returned as is. Otherwise, the following information is added to the query component of the given URL and is returned in the [AdobeCallback](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#adobecallback) instance:
+
+* The `adobe_mc` attribute is a URL encoded list that contains:
   * `MCMID` - Experience Cloud ID \(ECID\)
   * `MCORGID` - Experience Cloud Org ID
   * `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics)
@@ -235,11 +237,11 @@ Identity.appendVisitorInfoForURL("http://myurl.com", new AdobeCallback<String>()
 {% tab title="iOS" %}
 ### appendToURL <a id="appendToUrl-ios"></a>
 
-Appends Adobe visitor data to a URL.
+Appends Adobe visitor data to the query component of the given URL
 
-If the provided URL is nil or empty, it is returned as is. Otherwise, the following information is added to the url string that is returned via the callback:
+If the provided URL is nil or empty, it is returned as is. Otherwise, the following information is added to the query component of the given URL string and is returned via the callback:
 
-* The adobe\_mc attribute is an URL encoded list that contains:
+* The `adobe_mc` attribute is a URL encoded list that contains:
   * `MCMID` - Experience Cloud ID \(ECID\)
   * `MCORGID` - Experience Cloud Org ID
   * `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](../../adobe-analytics/)
@@ -278,9 +280,16 @@ ACPIdentity.append(to:URL(string: "www.myUrl.com"), withCallback: {(appendedURL)
 
 ### appendVisitorInfoForURL <a id="appendToUrl-js"></a>
 
-Appends Adobe visitor information to the given URL.
+Appends Adobe visitor information to the query component of the given URL.
 
-If the given url is nil or empty, it is returned as is. Otherwise, the following information is added to the query section of the given URL. The attribute `adobe_mc` is an URL encoded list containing the Experience Cloud ID, Experience Cloud Org ID, and a timestamp when this request was made. The attribute `adobe_aa_vid` is the URL encoded Visitor ID, however the attribute is only included if the Visitor ID was previously set.
+If the given url is nil or empty, it is returned as is. Otherwise, the following information is added to the query component of the given URL. 
+
+- The `adobe_mc` attribute is a URL encoded list that contains:
+  - `MCMID` - Experience Cloud ID \(ECID\)
+  - `MCORGID` - Experience Cloud Org ID
+  - `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](../../adobe-analytics/)
+  - `TS` - A timestamp taken when this request was made
+- The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://github.com/Adobe-Marketing-Cloud/aep-sdks-documentation/tree/174e9069bc1d3a521b59d52a066e9a7730f60ff5/using-mobile-extensions/adobe-analytics/analytics-api-reference/README.md#setidentifier).
 
 #### Syntax
 


### PR DESCRIPTION
Clarify the Identity.appendToURL API to state the Adobe visitor information is appended to the query component of the given URL.