### PR TITLE
Cleanup hint on Identity.appendVisitorInfoForUrl API reference

### DIFF
--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -233,7 +233,7 @@ Identity.appendVisitorInfoForURL("http://myurl.com", new AdobeCallback<String>()
 });
 ```
 {% hint style="info" %}
-This API is designed to handle URL formats: 
+This API is designed to handle the following URL formats: 
 
 ```basic
 scheme://authority/path?query=param#fragment 
@@ -257,7 +257,7 @@ The Adobe visitor data is appended as:
 scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
 ```
 
-If your application uses more complicated URLs, such as Angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-java).
+If your application uses more complicated URLs, such as Angular URLs, we recommend that you use [getUrlVariables](identity-api-reference.md#geturlvariables-java).
 {% endhint %}
 
 {% endtab %}
@@ -302,7 +302,7 @@ ACPIdentity.append(to:URL(string: "www.myUrl.com"), withCallback: {(appendedURL)
 });
 ```
 {% hint style="info" %}
-This API is designed to handle URL formats: 
+This API is designed to handle the following URL formats: 
 
 ```basic
 scheme://authority/path?query=param#fragment 
@@ -326,7 +326,7 @@ The Adobe visitor data is appended as:
 scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
 ```
 
-If your application uses more complicated URLs, such as Angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-ios).
+If your application uses more complicated URLs, such as Angular URLs, we recommend that you use [getUrlVariables](identity-api-reference.md#geturlvariables-ios).
 {% endhint %}
 
 {% endtab %}
@@ -359,7 +359,7 @@ ACPIdentity.appendVisitorInfoForURL(baseURL);
 ACPIdentity.appendVisitorInfoForURL("www.myUrl.com").then(urlWithVistorData => console.log("AdobeExperenceSDK: Url with Visitor Data = " + urlWithVisitorData));
 ```
 {% hint style="info" %}
-This API is designed to handle URL formats: 
+This API is designed to handle the following URL formats: 
 
 ```basic
 scheme://authority/path?query=param#fragment 
@@ -383,7 +383,7 @@ The Adobe visitor data is appended as:
 scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
 ```
 
-If your application uses more complicated URLs, such as Angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-js).
+If your application uses more complicated URLs, such as Angular URLs, we recommend that you use [getUrlVariables](identity-api-reference.md#geturlvariables-js).
 {% endhint %}
 
 {% endtab %}

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -211,12 +211,6 @@ If the provided URL is null or empty, it is returned as is. Otherwise, the follo
   * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics).
 
-{% hint style="info" %}
-This API is designed to handle URL formats: `scheme://authority/path?query=param#fragment`. In this example, the Adobe visitor data is appended as `scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment`
-
-If your application uses more complicated URLs, such as angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-java).
-{% endhint %}
-
 #### **Syntax**
 
 ```java
@@ -238,6 +232,34 @@ Identity.appendVisitorInfoForURL("http://myurl.com", new AdobeCallback<String>()
     }
 });
 ```
+{% hint style="info" %}
+This API is designed to handle URL formats: 
+
+```basic
+scheme://authority/path?query=param#fragment 
+```
+
+In this example, the Adobe visitor data is appended as:
+
+```basic
+scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
+```
+
+Similarly, URLs without a query component:
+
+```basic
+scheme://authority/path#fragment 
+```
+
+The Adobe visitor data is appended as: 
+
+```basic
+scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
+```
+
+If your application uses more complicated URLs, such as Angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-java).
+{% endhint %}
+
 {% endtab %}
 
 {% tab title="iOS" %}
@@ -253,12 +275,6 @@ If the provided URL is nil or empty, it is returned as is. Otherwise, the follow
   * `MCAID` - Analytics Tracking ID \(AID\), if available from the [Analytics extension](../../adobe-analytics/)
   * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://github.com/Adobe-Marketing-Cloud/aep-sdks-documentation/tree/174e9069bc1d3a521b59d52a066e9a7730f60ff5/using-mobile-extensions/adobe-analytics/analytics-api-reference/README.md#setidentifier).
-
-{% hint style="info" %}
-This API is designed to handle URL formats: `scheme://authority/path?query=param#fragment`. In this example, the Adobe visitor data is appended as `scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment`
-
-If your application uses more complicated URLs, such as angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-ios).
-{% endhint %}
 
 #### **Syntax**
 
@@ -285,6 +301,34 @@ ACPIdentity.append(to:URL(string: "www.myUrl.com"), withCallback: {(appendedURL)
 
 });
 ```
+{% hint style="info" %}
+This API is designed to handle URL formats: 
+
+```basic
+scheme://authority/path?query=param#fragment 
+```
+
+In this example, the Adobe visitor data is appended as:
+
+```basic
+scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
+```
+
+Similarly, URLs without a query component:
+
+```basic
+scheme://authority/path#fragment 
+```
+
+The Adobe visitor data is appended as: 
+
+```basic
+scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
+```
+
+If your application uses more complicated URLs, such as Angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-ios).
+{% endhint %}
+
 {% endtab %}
 
 {% tab title="React Native" %}
@@ -303,12 +347,6 @@ If the given url is nil or empty, it is returned as is. Otherwise, the following
   * `TS` - A timestamp taken when this request was made
 * The optional `adobe_aa_vid` attribute is the URL-encoded Analytics Custom Visitor ID \(VID\), if previously set in the [Analytics extension](https://github.com/Adobe-Marketing-Cloud/aep-sdks-documentation/tree/174e9069bc1d3a521b59d52a066e9a7730f60ff5/using-mobile-extensions/adobe-analytics/analytics-api-reference/README.md#setidentifier).
 
-{% hint style="info" %}
-This API is designed to handle URL formats: `scheme://authority/path?query=param#fragment`. In this example, the Adobe visitor data is appended as `scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment`
-
-If your application uses more complicated URLs, such as angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-js).
-{% endhint %}
-
 #### Syntax
 
 ```jsx
@@ -320,6 +358,34 @@ ACPIdentity.appendVisitorInfoForURL(baseURL);
 ```jsx
 ACPIdentity.appendVisitorInfoForURL("www.myUrl.com").then(urlWithVistorData => console.log("AdobeExperenceSDK: Url with Visitor Data = " + urlWithVisitorData));
 ```
+{% hint style="info" %}
+This API is designed to handle URL formats: 
+
+```basic
+scheme://authority/path?query=param#fragment 
+```
+
+In this example, the Adobe visitor data is appended as:
+
+```basic
+scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
+```
+
+Similarly, URLs without a query component:
+
+```basic
+scheme://authority/path#fragment 
+```
+
+The Adobe visitor data is appended as: 
+
+```basic
+scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
+```
+
+If your application uses more complicated URLs, such as Angular URLs, we recommend using [getUrlVariables](identity-api-reference.md#geturlvariables-js).
+{% endhint %}
+
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
1. Use code fences in info hint for Identity.appendVisitorInfoForUrl to allow horizontal scrolling of text.
2. Moved hint to bottom of card to improve reading flow.
3. Add another example of how the visitor data is appended to a URL.