### PR TITLE
Update TOC with data elements tutorial.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -70,6 +70,7 @@
 * [Tutorials](resources/user-guides/README.md)
   * [Tracking Beacons](resources/user-guides/track-beacon.md)
   * [Attach Data to SDK Events](resources/user-guides/attach-data.md)
+  * [Using data elements to define dynamic data in rules](resources/user-guides/launch-data-elements.md)
 * [Troubleshooting Guides](resources/troubleshooting-guides/README.md)
   * [Push Messaging](resources/troubleshooting-guides/troubleshooting-push.md)
 * [Building mobile extensions](resources/building-mobile-extensions/README.md)


### PR DESCRIPTION
Add launch-data-elements page to TOC as 'Using data elements to define dynamic data in rules' under Tutorials