### PR TITLE
Add step to save mobile property

### DIFF
--- a/getting-started/create-a-mobile-property.md
+++ b/getting-started/create-a-mobile-property.md
@@ -14,7 +14,7 @@ Having trouble creating a mobile property or need access to Experience Platform 
    If necessary, you can change the [**Privacy** ](../resources/privacy-and-gdpr.md#setting-privacy-status) and **HTTPS** settings later.
 
 3. Click **Save** to create the mobile property.
-4. Locate the new property in the **Properties** list displayed and open it.
+4. Locate the new property in the displayed Properties list and open it.
 
 {% hint style="danger" %}
 The default privacy status is set to _opted in_ and might impact data collection. For more information, see [Privacy and GDPR](../resources/privacy-and-gdpr.md).

--- a/getting-started/create-a-mobile-property.md
+++ b/getting-started/create-a-mobile-property.md
@@ -13,7 +13,8 @@ Having trouble creating a mobile property or need access to Experience Platform 
 
    If necessary, you can change the [**Privacy** ](../resources/privacy-and-gdpr.md#setting-privacy-status) and **HTTPS** settings later.
 
-3. Locate the new property in the **Properties** list and open it.
+3. Click **Save** to create the mobile property.
+4. Locate the new property in the **Properties** list displayed and open it.
 
 {% hint style="danger" %}
 The default privacy status is set to _opted in_ and might impact data collection. For more information, see [Privacy and GDPR](../resources/privacy-and-gdpr.md).


### PR DESCRIPTION
Little confusing to know where the list of properties described is at unless you save first. Some customers were missing that step.