### PR TITLE
Update cordova AEP SDK doc readme files

### DIFF
--- a/beta/project-griffon/set-up-project-griffon/README.md
+++ b/beta/project-griffon/set-up-project-griffon/README.md
@@ -88,11 +88,22 @@ import ACPCore
 import ACPGriffon // <-- import the Project Griffon library
 ```
 {% endtab %}
-
 {% tab title="Flutter" %}
-**Dart**
+
+#### Dart
 
 Flutter install instructions for Griffon can be found [here](https://pub.dev/packages/flutter_griffon#-installing-tab-).
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+After creating your Cordova app and adding the Android and iOS platforms, the Project Griffon extension for Cordova can be added with this command:
+
+```
+cordova plugin add https://github.com/adobe/cordova-acpgriffon.git
+```
+
 {% endtab %}
 {% endtabs %}
 
@@ -155,6 +166,9 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 {% tab title="Flutter" %}
 When using Flutter, registering Griffon with Mobile Core should be done in native code which is shown under the Android and iOS tabs.
 {% endtab %}
+{% tab title="Cordova" %}
+When using Cordova, registering Griffon with Mobile Core must be done in native code which is shown under the Android and iOS tabs.
+{% endtab %}
 {% endtabs %}
 
 #### Implement Project Griffon session start APIs \(iOS\)
@@ -208,6 +222,27 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
         ACPGriffon.startSession((URLContexts.first!).url)
 }
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+### startSession
+
+#### Syntax
+
+```objectivec
+ACPGriffon.startSession(url, success, error);
+```
+
+#### Example
+
+```jsx
+ACPGriffon.startSession(sessionUrl, function(handleCallback) {
+  console.log("AdobeExperenceSDK: Griffon session start successful: " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to start griffon session: " + handleError);
+});
+```
+
 {% endtab %}
 {% endtabs %}
 

--- a/beta/project-griffon/set-up-project-griffon/README.md
+++ b/beta/project-griffon/set-up-project-griffon/README.md
@@ -229,7 +229,7 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 
 #### Syntax
 
-```objectivec
+```jsx
 ACPGriffon.startSession(url, success, error);
 ```
 

--- a/beta/project-griffon/set-up-project-griffon/project-griffon-sdk-api-reference.md
+++ b/beta/project-griffon/set-up-project-griffon/project-griffon-sdk-api-reference.md
@@ -76,6 +76,31 @@ static Future<void> startSession(String url);
 FlutterGriffon.startSession(url);
 ```
 {% endtab %}
+{% tab title="Cordova" %}
+
+### Cordova
+
+### Syntax
+
+```jsx
+ACPGriffon.startSession(url, success, error);
+```
+
+* _url_ _\(String\)_ is the griffon session url.
+* _success_ is a callback which indicates if the `startSession` API was executed without errors.
+* _error_ is a callback containing error information if the `startSession` API was executed with errors.
+
+### Example
+
+```jsx
+ACPGriffon.startSession(url, function(handleCallback) {
+  console.log("AdobeExperenceSDK: Griffon session start successful: " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to start griffon session: " + handleError);
+});
+```
+
+{% endtab %}
 {% endtabs %}
 
 ## endSession

--- a/using-mobile-extensions/adobe-analytics/README.md
+++ b/using-mobile-extensions/adobe-analytics/README.md
@@ -198,14 +198,15 @@ _Note_ For `iOS` using `cocoapods`, run:
    ```
 
 {% endtab %}
-
 {% tab title="Cordova" %}
 
 #### Cordova
 
-1. Install Analytics.
+1. After creating your Cordova app and adding the Android and iOS platforms, the Analytics extension for Cordova can be added with this command:
 
-   Instructions on installing the Analytics SDK in Cordova can be found [here](https://github.com/adobe/cordova-acpanalytics).
+   ```
+   cordova plugin add https://github.com/adobe/cordova-acpanalytics.git
+   ```
 
 2. Get the extension version.
 
@@ -218,7 +219,6 @@ _Note_ For `iOS` using `cocoapods`, run:
    ```
 
 {% endtab %}
-
 {% endtabs %}
 
 ### Register Analytics with Mobile Core
@@ -293,6 +293,13 @@ When using React Native, registering Analytics with Mobile Core should be done i
 #### Dart
 
 When using Flutter, registering Analytics with Mobile Core should be done in native code which is shown under the Android and iOS tabs.
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+When using Cordova, registering Analytics with Mobile Core must be done in native code which is shown under the Android and iOS tabs.
+
 {% endtab %}
 {% endtabs %}
 
@@ -426,6 +433,38 @@ FlutterACPCore.trackAction("Action Name",  data: contextData);
 FlutterACPCore.trackState("State Name",  data: contextData);
 ```
 {% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+#### Syntax
+
+```jsx
+var contextData = {"eventN:serial number": "&&events"};
+```
+
+#### Example
+
+```jsx
+// create a context data dictionary and add events
+var contextData = {"event1:12341234": "&&events"};
+
+// send the tracking call - use either a trackAction or trackState call.
+// trackAction example:
+ACPCore.trackAction("Action Name", contextData, function(handleCallback) {
+  console.log("AdobeExperenceSDK: Track action success: " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to track action: " + handleError);
+});
+// trackState example:
+ACPCore.trackState("State Name", contextData, function(handleCallback) {
+  console.log("AdobeExperenceSDK: Track state success: " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to track state: " + handleError);
+});
+```
+
+{% endtab %}
 {% endtabs %}
 
 ## Videos
@@ -534,6 +573,24 @@ FlutterACPCore.updateConfiguration({"analytics.server": "sample.analytics.tracki
                                     "analytics.batchLimit": 10,
                                     "analytics.offlineEnabled": true});
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+### Update Analytics Configuration
+
+```jsx
+ACPCore.updateConfiguration({"analytics.server": "sample.analytics.tracking.server",
+                             "analytics.rsids": "rsid1,rsid2",
+                             "analytics.batchLimit": 10,
+                             "analytics.offlineEnabled": true}, function(handleCallback) {
+  console.log("AdobeExperenceSDK: Analytics configuration update success: " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to update analytics configuration: " + handleError);
+});
+```
+
 {% endtab %}
 {% endtabs %}
 

--- a/using-mobile-extensions/mobile-core/configuration/README.md
+++ b/using-mobile-extensions/mobile-core/configuration/README.md
@@ -42,6 +42,13 @@ ACPCore.configure(withAppId: "1423ae38-8385-8963-8693-28375403491d")
 Alternatively, you can also place the Launch environment ID in your iOS project's _Info.plist_ with the `ADBMobileAppID` key. When the SDK is initialized, the environment ID is automatically read from the _Info.plist_ file and the associated configuration.
 {% endhint %}
 {% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+When using Cordova, the `configureWithAppId` method call must be done in native code which is shown under the Android and iOS tabs.
+
+{% endtab %}
 {% endtabs %}
 
 ## Programmatic updates to configuration
@@ -97,6 +104,19 @@ ACPCore.updateConfiguration({"global.privacy":"optedout"});
 ```dart
 FlutterACPCore.updateConfiguration({"global.privacy":"optedout"});
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+```jsx
+ACPCore.updateConfiguration({"global.privacy":"optedout"}, function(handleCallback) {
+  console.log("AdobeExperenceSDK: Update configuration successful: " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to update configuration : " + handleError);
+});
+```
+
 {% endtab %}
 {% endtabs %}
 

--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -69,6 +69,17 @@ Import the Identity extension:
 import 'package:flutter_acpcore/flutter_acpidentity.dart';
 ```
 {% endtab %}
+{% tab title="Cordova" %}
+
+### Cordova
+
+After creating your Cordova app and adding the Android and iOS platforms, the Identity extension for Cordova can be added with this command:
+
+```
+cordova plugin add https://github.com/adobe/cordova-acpcore.git
+```
+
+{% endtab %}
 {% endtabs %}
 
 ## Register the Identity extension
@@ -136,6 +147,13 @@ When using React Native, registering Identity with Mobile Core should be done in
 
 When using Flutter, registering Identity with Mobile Core should be done in native code which is shown under the Android and iOS tabs.
 {% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+When using Cordova, registering Identity with Mobile Core must be done in native code which is shown under the Android and iOS tabs.
+
+{% endtab %}
 {% endtabs %}
 
 {% hint style="info" %}
@@ -189,6 +207,19 @@ ACPIdentity.extensionVersion().then(identityExtensionVersion => console.log("Ide
 ```dart
 String identityExtensionVersion = await FlutterACPIdentity.extensionVersion;
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+```jsx
+ACPIdentity.extensionVersion(function (handleCallback) {
+  console.log("AdobeExperienceSDK: ACPIdentity version: " + handleCallback)
+}, function (handleError) {
+  console.log("AdobeExperenceSDK: failed to get extension version : " + handleError)
+});
+```
+
 {% endtab %}
 {% endtabs %}
 
@@ -322,6 +353,32 @@ try {
   log("Failed to get url variables");
 }
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+To append visitor information to the URL that is being used to open the web view, call [appendVisitorInfoForUrl](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#appendvisitorinfoforurl-4):
+
+```jsx
+ACPIdentity.appendVisitorInfoForUrl("https://example.com", function(handleCallback) {
+  console.log("AdobeExperenceSDK: Url with Visitor Data = " + handleCallback);
+}, function(handleError) {
+  console.log("AdobeExperenceSDK: Failed to append URL : " + handleError);
+});
+```
+
+Alternately, you can call [getUrlVariables](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#geturlvariables-5) and build your own URL:
+
+```jsx
+ACPIdentity.getUrlVariables(function (handleCallback) {
+  console.log("AdobeExperienceSDK: Url variables: " + handleCallback);
+}, function (handleError) {
+  console.log("AdobeExperenceSDK: Failed to retrieve url variables : " + handleError);
+});
+```
+
+
 {% endtab %}
 {% endtabs %}
 

--- a/using-mobile-extensions/mobile-core/lifecycle/README.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/README.md
@@ -57,6 +57,17 @@ Import the Lifecycle extension
 import 'package:flutter_acpcore/flutter_acplifecycle.dart';
 ```
 {% endtab %}
+{% tab title="Cordova" %}
+
+### Cordova
+
+After creating your Cordova app and adding the Android and iOS platforms, the Lifecycle extension for Cordova can be added with this command:
+
+```
+cordova plugin add https://github.com/adobe/cordova-acpcore.git
+```
+
+{% endtab %}
 {% endtabs %}
 
 ## Register Lifecycle with Mobile Core and add appropriate Start/Pause calls
@@ -217,6 +228,11 @@ ACPCore.lifecycleStart({"lifecycleStart": "myData"});
 ```jsx
 ACPCore.lifecyclePause();
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+When using Cordova, registering Lifecycle with Mobile Core must be done in native code which is shown under the Android and iOS tabs.
+
 {% endtab %}
 {% endtabs %}
 

--- a/using-mobile-extensions/mobile-core/lifecycle/lifecycle-api-reference.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/lifecycle-api-reference.md
@@ -147,6 +147,13 @@ lifecycleStart(additionalContextData?: { string: string });
 ACPCore.lifecycleStart({"lifecycleStart": "myData"});
 ```
 {% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+When using Cordova, the `lifecycleStart` method call must be done in native code which is shown under the Android and iOS tabs.
+
+{% endtab %}
 {% endtabs %}
 
 ### Lifecycle Pause
@@ -210,6 +217,13 @@ lifecyclePause();
 ```jsx
 ACPCore.lifecyclePause();
 ```
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+When using Cordova, the `lifecyclePause` method call must be done in native code which is shown under the Android and iOS tabs.
+
 {% endtab %}
 {% endtabs %}
 

--- a/using-mobile-extensions/mobile-core/signals/README.md
+++ b/using-mobile-extensions/mobile-core/signals/README.md
@@ -83,6 +83,17 @@ Importing the Signal extension:
 import 'package:flutter_acpcore/flutter_acpsignal.dart';
 ```
 {% endtab %}
+{% tab title="Cordova" %}
+
+### Cordova
+
+After creating your Cordova app and adding the Android and iOS platforms, the Signal extension for Cordova can be added with this command:
+
+```
+cordova plugin add https://github.com/adobe/cordova-acpcore.git
+```
+
+{% endtab %}
 {% endtabs %}
 
 ### Register the Signal extension
@@ -158,6 +169,13 @@ When using React Native, registering Signal with Mobile Core should be done in n
 #### Dart
 
 When using Flutter, registering Signal with Mobile Core should be done in native code which is shown under the Android and iOS tabs.
+{% endtab %}
+{% tab title="Cordova" %}
+
+#### Cordova
+
+When using Cordova, registering Signal with Mobile Core must be done in native code which is shown under the Android and iOS tabs.
+
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
- also add docs for cordova griffon.
- add information regarding which AEP SDK API must be called natively.