### PR TITLE
Update obj-c&Android samples for network service overrider

### DIFF
--- a/using-mobile-extensions/mobile-core/platform-services.md
+++ b/using-mobile-extensions/mobile-core/platform-services.md
@@ -186,7 +186,7 @@ The completion block for the `requestUrl` method takes an `ACPHttpConnection` as
 
 	// Modifications here would allow for conditional overriding based on the url/method.
   // In this example it always returns true to override all network requests.
-- (BOOL) shouldOverride: (NSString*) url method: (NSString*) method {
+- (BOOL) shouldOverride: (NSURL*) url method: (NSString*) method {
     return true;
 }
 

--- a/using-mobile-extensions/mobile-core/platform-services.md
+++ b/using-mobile-extensions/mobile-core/platform-services.md
@@ -170,6 +170,8 @@ The completion block for the `requestUrl` method takes an `ACPHttpConnection` as
 
 #### Example
 
+This is just an implementation example. For more information about handling network requests correctly in your mobile application, see [NSURLSessionConfiguration](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration) and [NSMutableURLRequest](https://developer.apple.com/documentation/foundation/nsmutableurlrequest).
+
 **Objective-C**
 
 ```objectivec
@@ -207,6 +209,15 @@ The completion block for the `requestUrl` method takes an `ACPHttpConnection` as
     [request setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
     [request setHTTPMethod:command];
     [request setURL:url];
+  
+  	if (payload.length > 0 && [@"POST" isEqualToString:[command uppercaseString]]) {
+       [request setHTTPBody:[payload dataUsingEncoding:NSUTF8StringEncoding]];
+    }
+    
+    for (NSString *key in requestProperty) {
+        NSString* value = requestProperty[key];
+        [request setValue:value forHTTPHeaderField:key];
+    }
 
     // Start the request
     NSURLSessionDataTask* task;

--- a/using-mobile-extensions/mobile-core/platform-services.md
+++ b/using-mobile-extensions/mobile-core/platform-services.md
@@ -10,7 +10,10 @@ This section walks through the steps necessary to create a custom network overri
 This feature is only available in Android Core version 2.5.0 or later and iOS Core version 2.6.0 or later.
 {% endhint %}
 
-## Android
+
+
+{% tabs %}
+{% tab title="Android" %}
 
 ### 1. Create custom HTTPConnectionPerformer implementation
 
@@ -21,106 +24,106 @@ The `HTTPConnectionPerformer` class is an abstract base class that must be subcl
 ```java
 package com.adobe.example;
 
-    import java.io.BufferedOutputStream;
-    import java.io.IOException;
-    import java.io.InputStream;
-    import java.io.OutputStream;
-    import java.net.HttpURLConnection;
-    import java.net.MalformedURLException;
-    import java.net.URL;
-    import java.util.Map;
-    import com.adobe.marketing.mobile.AndroidNetworkServiceOverrider.HTTPConnectionPerformer;
-    import com.adobe.marketing.mobile.AndroidNetworkServiceOverrider.Connection;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import com.adobe.marketing.mobile.AndroidNetworkServiceOverrider.HTTPConnectionPerformer;
+import com.adobe.marketing.mobile.AndroidNetworkServiceOverrider.Connection;
 
-    // Sample implementation of HTTPConnectionPerformer for AEP SDK Network Override.
-    class SampleHTTPConnectionPerformer extends HTTPConnectionPerformer {        
-        // Modifications here would allow for conditional overriding based on the url/method.
-        // Overriding this method is optional, by default it will always return true (meaning
-        // all network requests should be overridden).
+// Sample implementation of HTTPConnectionPerformer for AEP SDK Network Override.
+class SampleHTTPConnectionPerformer extends HTTPConnectionPerformer {        
+  // Modifications here would allow for conditional overriding based on the url/method.
+  // Overriding this method is optional, by default it will always return true (meaning
+  // all network requests should be overridden).
+  @Override
+  public boolean shouldOverride(String url, String method) {
+    return true;
+  }
+
+  // Overriding the connect method is required.  This method must perform a synchronous
+  // (blocking) network request.  Upon success, return an object conforming to the
+  // Connection interface.  Upon error, return one of these values:
+  //  - URL Parsing / Malformed issues - CONNECTION_ERROR_URL
+  //  - IO / Other errors - CONNECTION_ERROR_IO
+  @Override
+  public Connection connect(String url, String method, byte[] payload, Map<String, String> headers, int connectionTimeoutSeconds, int readTimeoutSeconds) {
+    try {
+      final URL dest = new URL(url);
+      final HttpURLConnection con = (HttpURLConnection) dest.openConnection();
+      con.setReadTimeout(readTimeoutSeconds * 1000);
+      con.setConnectTimeout(connectionTimeoutSeconds * 1000);
+
+      con.setRequestMethod(method);
+
+      for (final Map.Entry<String, String> entry : headers.entrySet()) {
+        con.setRequestProperty(entry.getKey(), entry.getValue());
+      }
+
+      if (method.equals("POST") && payload != null) {
+        con.setFixedLengthStreamingMode(payload.length);
+      }
+
+      con.connect();
+
+      if (method.equals("POST") && payload != null) {
+        final OutputStream os = new BufferedOutputStream(con.getOutputStream());
+        os.write(payload);
+        os.flush();
+        os.close();
+      }
+
+      final InputStream inputStream = con.getInputStream();
+      final int responseCode = con.getResponseCode();
+      final String responseMessage = con.getResponseMessage();
+
+      return new AndroidNetworkServiceOverrider.Connection() {
         @Override
-        public boolean shouldOverride(String url, String method) {
-            return true;
+        public InputStream getInputStream() {
+          return inputStream;
         }
 
-        // Overriding the connect method is required.  This method must perform a synchronous 
-        // (blocking) network request.  Upon success, return an object conforming to the 
-        // Connection interface.  Upon error, return one of these values:
-        //    URL Parsing / Malformed issues - CONNECTION_ERROR_URL
-        //      IO / Other errors - CONNECTION_ERROR_IO
         @Override
-        public Connection connect(String url, String method, byte[] payload, Map<String, String> headers, int connectionTimeoutSeconds, int readTimeoutSeconds) {
+        public int getResponseCode() {
+          return responseCode;
+        }
+
+        @Override
+        public String getResponseMessage() {
+          return responseMessage;
+        }
+
+        @Override
+        public String getResponsePropertyValue(String responsePropertyKey) {
+          final String responseHeaderValue = con.getHeaderField(responsePropertyKey);
+          return responseHeaderValue;
+        }
+
+        @Override
+        public void close() {
+          if (inputStream != null) {
             try {
-                final URL dest = new URL(url);
-                final HttpURLConnection con = (HttpURLConnection) dest.openConnection();
-                con.setReadTimeout(readTimeoutSeconds * 1000);
-                con.setConnectTimeout(connectionTimeoutSeconds * 1000);
-
-                con.setRequestMethod(method);
-
-                for (final Map.Entry<String, String> entry : headers.entrySet()) {
-                    con.setRequestProperty(entry.getKey(), entry.getValue());
-                }
-
-                if (method.equals("POST") && payload != null) {
-                    con.setFixedLengthStreamingMode(payload.length);
-                }
-
-                con.connect();
-
-                if (method.equals("POST") && payload != null) {
-                    final OutputStream os = new BufferedOutputStream(con.getOutputStream());
-                    os.write(payload);
-                    os.flush();
-                    os.close();
-                }
-
-                final InputStream inputStream = con.getInputStream();
-                final int responseCode = con.getResponseCode();
-                final String responseMessage = con.getResponseMessage();
-
-                return new AndroidNetworkServiceOverrider.Connection() {
-                    @Override
-                    public InputStream getInputStream() {
-                        return inputStream;
-                    }
-
-                    @Override
-                    public int getResponseCode() {
-                        return responseCode;
-                    }
-
-                    @Override
-                    public String getResponseMessage() {
-                        return responseMessage;
-                    }
-
-                    @Override
-                    public String getResponsePropertyValue(String responsePropertyKey) {
-                        final String responseHeaderValue = con.getHeaderField(responsePropertyKey);
-                        return responseHeaderValue;
-                    }
-
-                    @Override
-                    public void close() {
-                        if (inputStream != null) {
-                            try {
-                                inputStream.close();
-                            } catch (final Exception ex) {
-                            }
-                        }
-                        con.disconnect();
-                    }
-                };
-
-
-            } catch (final MalformedURLException ex) {
-                return CONNECTION_ERROR_URL;
-
-            } catch (final IOException ex) {
-                return CONNECTION_ERROR_IO;
+              inputStream.close();
+            } catch (final Exception ex) {
             }
+          }
+          con.disconnect();
         }
+      };
+
+
+    } catch (final MalformedURLException ex) {
+      return CONNECTION_ERROR_URL;
+
+    } catch (final IOException ex) {
+      return CONNECTION_ERROR_IO;
     }
+  }
+}
 ```
 
 {% hint style="info" %}
@@ -135,20 +138,24 @@ Your implementation must return an object conforming to the `Connection` interfa
 This step should occur prior to any other interactions with the AEP SDK. While it's possible to register the network override at any point during the application lifecycle, the override will only function for network requests performed after the registration has taken place.
 
 ```java
-    public void onCreate() {
-        super.onCreate();
+import com.adobe.marketing.mobile.AndroidNetworkServiceOverrider;
+import com.adobe.marketing.mobile.MobileCore;
 
-        // Register network override prior to making any other calls to the AEP SDK
-        AndroidNetworkServiceOverrider.setHTTPConnectionPerformer(new MyCustomNetworkOverride());
+public void onCreate() {
+	super.onCreate();
 
-        // First call to AEP SDK
-        MobileCore.setApplication(this);
+  // Register network override prior to making any other calls to the AEP SDK
+  AndroidNetworkServiceOverrider.setHTTPConnectionPerformer(new SampleHTTPConnectionPerformer());
 
-        //... continue with initialization / registering extensions.
-    }
+  // First call to AEP SDK
+  MobileCore.setApplication(this);
+  //... continue with initialization / registering extensions.
+}
 ```
 
-## iOS
+{% endtab %}
+
+{% tab title="iOS" %}
 
 ### 1. Conform to the ACPHttpConnectionPerformer protocol
 
@@ -166,14 +173,19 @@ The completion block for the `requestUrl` method takes an `ACPHttpConnection` as
 **Objective-C**
 
 ```objectivec
-@interface YourPerformerOverrider : NSObject<ACPHttpConnectionPerformer>
+#import <Foundation/Foundation.h>
+#import "ACPNetworkServiceOverrider.h"
+
+@interface SamplePerformerOverrider : NSObject<ACPHttpConnectionPerformer>
 
 @end
 
-@implementation YourPerformerOverrider {
+@implementation SamplePerformerOverrider {
     void (^requestUrlCompletion)(ACPHttpConnection*);
 }
 
+	// Modifications here would allow for conditional overriding based on the url/method.
+  // In this example it always returns true to override all network requests.
 - (BOOL) shouldOverride: (NSString*) url method: (NSString*) method {
     return true;
 }
@@ -182,16 +194,24 @@ The completion block for the `requestUrl` method takes an `ACPHttpConnection` as
 
     requestUrlCompletion = completion;
 
-    ... URL configuration code ...
+    // Create the NSURLSessionConfiguration with the provided timeouts
+    NSURLSessionConfiguration* config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    config.URLCache = nil;
+    config.timeoutIntervalForRequest = readTimeout;
+    config.timeoutIntervalForResource = connectTimeout;
 
     NSURLSession* session = [NSURLSession sessionWithConfiguration:config];
+    
+    // Create an NSURLRequest with the provided request parameters
+    NSMutableURLRequest* request = [NSMutableURLRequest new];
+    [request setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
+    [request setHTTPMethod:command];
+    [request setURL:url];
 
     // Start the request
     NSURLSessionDataTask* task;
     task = [session dataTaskWithRequest:request
-                      completionHandler: ^ (NSData * data,
-                                          NSURLResponse * response,
-            NSError * error) {
+                      completionHandler: ^ (NSData * data, NSURLResponse * response, NSError * error) {
                 if(!error) {
                     NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
 
@@ -211,7 +231,7 @@ The completion block for the `requestUrl` method takes an `ACPHttpConnection` as
 **Swift**
 
 ```swift
-class YourPerformerOverrider: ACPHttpConnectionPerformer {
+class SamplePerformerOverrider: ACPHttpConnectionPerformer {
     func shouldOverride(_ url: URL, method: String) -> Bool {
         return true
     }
@@ -242,12 +262,15 @@ This step should occur prior to any other interactions with the AEP SDK. While i
 **Objective-C**
 
 ```objectivec
+#import "SamplePerformerOverrider.h"
+#import "ACPCore.h"
+
 @implementation AppDelegate
 
 -(BOOL)application:(UIApplication *)application 
 didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions {
         ...
-        [ACPNetworkServiceOverrider setHttpConnectionPerformer:[[YourPerformerOverrider alloc] init]];
+        [ACPNetworkServiceOverrider setHttpConnectionPerformer:[[SamplePerformerOverrider alloc] init]];
         ...
         [ACPCore start:^{
         ...
@@ -262,9 +285,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     func applicationDidFinishLaunching(_ application: UIApplication) {
         ...
-        ACPNetworkServiceOverrider.setHttpConnectionPerformer(YourPerformerOverrider())
+        ACPNetworkServiceOverrider.setHttpConnectionPerformer(SamplePerformerOverrider())
         ACPCore.start {
         ...
         }
 ```
 
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
- Formatting and added tabs for iOS&Android
- Add imports/includes required for these examples
- Add obj-c example for creating NSURLSessionConfiguration and NSMutableURLRequest