### PR TITLE
UISceneDelegate iOS 13 documentation for LifeCycle and Griffon

### DIFF
--- a/beta/project-griffon/set-up-project-griffon/README.md
+++ b/beta/project-griffon/set-up-project-griffon/README.md
@@ -188,6 +188,17 @@ You may call this API when the app launches with a url \(see code snippet below 
 }
 ```
 
+In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `scene(_:openURLContexts:)` method as follows:
+
+```objectivec
+- (void) scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+    UIOpenURLContext * urlContext = URLContexts.anyObject;
+    if (urlContext != nil) {
+        [ACPGriffon startSession:urlContext.URL];
+    }
+}
+```
+
 #### Swift
 
 #### Example
@@ -201,7 +212,7 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
 }
 ```
 
-In iOS 13 and later, for a scene-based application.
+In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `scene(_:openURLContexts:)` method as follows:
 
 ```swift
 func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/using-mobile-extensions/mobile-core/lifecycle/README.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/README.md
@@ -143,6 +143,13 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
        [ACPCore lifecycleStart:nil];
    }
    ```
+   NOTE: If you are using `UISceneDelegate`, then you should use the `sceneWillEnterForeground` delegate method as follows:
+   
+   ```objectivec
+   - (void) sceneWillEnterForeground:(UIScene *)scene {
+      [ACPCore lifecycleStart:nil];
+   }
+   ```
 
 4. When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
 
@@ -150,6 +157,14 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
     - (void) applicationDidEnterBackground:(UIApplication *)application {
        [ACPCore lifecyclePause];
     }
+   ```
+   
+   NOTE: If you are using `UISceneDelegate`, then you should use the `sceneDidEnterBackground` delegate method as follows:
+   
+   ```objectivec
+   - (void) sceneDidEnterBackground:(UIScene *)scene {
+      [ACPCore lifecyclePause];
+   }
    ```
 
 ### Swift
@@ -189,6 +204,14 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
        ACPCore.lifecycleStart(nil)
    }
    ```
+   
+   NOTE: If you are using `UISceneDelegate`, then you should use the `sceneWillEnterForeground` delegate method as follows:
+   
+   ```swift
+   func sceneWillEnterForeground(_ scene: UIScene) {
+        ACPCore.lifecycleStart(nil)
+   }
+   ```
 
 4. When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
 
@@ -197,6 +220,15 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
        ACPCore.lifecyclePause()
    }
    ```
+   
+      NOTE: If you are using `UISceneDelegate`, then you should use the `sceneDidEnterBackground` delegate method as follows:
+   
+   ```swift
+   func sceneDidEnterBackground(_ scene: UIScene) {
+        ACPCore.lifecyclePause()
+   }
+   ```
+   
 {% endtab %}
 
 {% tab title="React Native" %}

--- a/using-mobile-extensions/mobile-core/lifecycle/README.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/README.md
@@ -150,6 +150,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
       [ACPCore lifecycleStart:nil];
    }
    ```
+   For more information on handling foregrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_foreground?language=objc) 
 
 4. When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
 
@@ -159,13 +160,14 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
     }
    ```
    
-   In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneDidEnterForeground` method as follows:   
+   In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneDidEnterBackground` method as follows:   
    
    ```objectivec
    - (void) sceneDidEnterBackground:(UIScene *)scene {
       [ACPCore lifecyclePause];
    }
    ```
+   For more information on handling backgrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background?language=objc) 
 
 ### Swift
 
@@ -211,6 +213,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
         ACPCore.lifecycleStart(nil)
    }
    ```
+For more information on handling foregrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_foreground) 
 
 4. When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
 
@@ -225,6 +228,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
         ACPCore.lifecyclePause()
    }
    ```
+   For more information on handling backgrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background) 
    
 {% endtab %}
 

--- a/using-mobile-extensions/mobile-core/lifecycle/README.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/README.md
@@ -143,7 +143,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
        [ACPCore lifecycleStart:nil];
    }
    ```
-   NOTE: If you are using `UISceneDelegate`, then you should use the `sceneWillEnterForeground` delegate method as follows:
+   In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneWillEnterForeground` method as follows:
    
    ```objectivec
    - (void) sceneWillEnterForeground:(UIScene *)scene {
@@ -159,7 +159,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
     }
    ```
    
-   NOTE: If you are using `UISceneDelegate`, then you should use the `sceneDidEnterBackground` delegate method as follows:
+   In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneDidEnterForeground` method as follows:   
    
    ```objectivec
    - (void) sceneDidEnterBackground:(UIScene *)scene {
@@ -204,8 +204,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
        ACPCore.lifecycleStart(nil)
    }
    ```
-   
-   NOTE: If you are using `UISceneDelegate`, then you should use the `sceneWillEnterForeground` delegate method as follows:
+      In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneWillEnterForeground` method as follows:
    
    ```swift
    func sceneWillEnterForeground(_ scene: UIScene) {
@@ -220,9 +219,7 @@ import 'package:flutter_acpcore/flutter_acplifecycle.dart';
        ACPCore.lifecyclePause()
    }
    ```
-   
-      NOTE: If you are using `UISceneDelegate`, then you should use the `sceneDidEnterBackground` delegate method as follows:
-   
+      In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneDidEnterBackground` method as follows:
    ```swift
    func sceneDidEnterBackground(_ scene: UIScene) {
         ACPCore.lifecyclePause()


### PR DESCRIPTION
With iOS 13, Apple introduced [Scenes](https://developer.apple.com/documentation/uikit/app_and_environment/scenes?language=objc) which affects the hooks for the application lifecycle. If an app is using Scenes, the `UISceneDelegate` is used for certain lifecycle hooks instead of the `AppDelegate`. In order to clarify our lifecycle documentation as well as the Griffon `startSession` documentation, we have added some example code to support Scenes. 