### PR TITLE
clean up xamarin docs

### DIFF
--- a/beta/project-griffon/set-up-project-griffon/README.md
+++ b/beta/project-griffon/set-up-project-griffon/README.md
@@ -120,13 +120,13 @@ using com.adobe.marketing.mobile;
 
 1. After adding the iOS or Android ACPGriffon NuGet package, the Griffon extension can be added by this import statement
 
-   ```text
+   ```csharp
    using Com.Adobe.Marketing.Mobile;
    ```
 
 2. Get the extension version.
 
-   ```text
+   ```csharp
    ACPGriffon.ExtensionVersion();
    ```
 {% endtab %}
@@ -221,7 +221,7 @@ public class MainScript : MonoBehaviour
 
 Register the Griffon extension in your app's `FinishedLaunching()` function:
 
-```text
+```csharp
 public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
   global::Xamarin.Forms.Forms.Init();
@@ -243,7 +243,7 @@ private void startCallback()
 
 Set the current activity with ACPCore via the ACPCoreBridge and register the Griffon extension in your app's `OnCreate()` function:
 
-```text
+```csharp
 protected override void OnCreate(Bundle savedInstanceState)
 {
   base.OnCreate(savedInstanceState);
@@ -378,26 +378,26 @@ ACPGriffon.StartSession("griffonexample//?adb_validation_sessionid=f35ed0d7-e235
 
 #### iOS Syntax
 
-```text
+```csharp
 public static void StartSession (NSUrl url);
 ```
 
 #### Android Syntax
 
-```text
+```csharp
 public unsafe static void StartSession (string url);
 ```
 
 #### iOS Example
 
-```text
+```csharp
 NSUrl url = new NSUrl("session url");
 ACPGriffon.StartSession(url);
 ```
 
 #### Android Example
 
-```text
+```csharp
 ACPGriffon.StartSession("session url");
 ```
 {% endtab %}

--- a/beta/project-griffon/set-up-project-griffon/project-griffon-sdk-api-reference.md
+++ b/beta/project-griffon/set-up-project-griffon/project-griffon-sdk-api-reference.md
@@ -122,7 +122,7 @@ ACPGriffon.StartSession("griffonexample//?adb_validation_sessionid=f35ed0d7-e235
 
 #### iOS Syntax
 
-```text
+```csharp
 public static void StartSession (NSUrl url);
 ```
 
@@ -130,7 +130,7 @@ public static void StartSession (NSUrl url);
 
 #### Android Syntax
 
-```text
+```csharp
 public unsafe static void StartSession (string url);
 ```
 
@@ -138,14 +138,14 @@ public unsafe static void StartSession (string url);
 
 #### iOS Example
 
-```text
+```csharp
 NSUrl url = new NSUrl("session url");
 ACPGriffon.StartSession(url);
 ```
 
 #### Android Example
 
-```text
+```csharp
 ACPGriffon.StartSession("session url");
 ```
 {% endtab %}

--- a/getting-started/enable-lifecycle-metrics.md
+++ b/getting-started/enable-lifecycle-metrics.md
@@ -179,6 +179,49 @@ private void OnApplicationPause(bool pauseStatus)
 }
 ```
 {% endtab %}
+
+{% tab title="Xamarin" %}
+
+## C\#
+
+**iOS**
+
+Starting and pausing a lifecycle event
+
+```csharp
+public override void WillEnterForeground(UIApplication uiApplication)
+{
+  base.WillEnterForeground(uiApplication);
+  ACPCore.LifecycleStart(null);
+}
+
+public override void DidEnterBackground(UIApplication uiApplication)
+{
+  base.DidEnterBackground(uiApplication);
+  ACPCore.LifecycleStart(null);
+}
+```
+
+**Android**
+
+Starting and pausing a lifecycle event
+
+```csharp
+protected override void OnResume()
+{
+  base.OnResume();
+  ACPCore.LifecycleStart(null);
+}
+
+protected override void OnPause()
+{
+  base.OnPause();
+  ACPCore.LifecyclePause();
+}
+```
+
+{% endtab %}
+
 {% endtabs %}
 
 For more information, see [Lifecycle Metrics](../using-mobile-extensions/mobile-core/lifecycle/).

--- a/getting-started/get-the-sdk.md
+++ b/getting-started/get-the-sdk.md
@@ -404,7 +404,7 @@ For Xamarin Forms apps, the SDK intialization differs depending on the platform 
 
 **iOS**
 
-```text
+```csharp
 using Com.Adobe.Marketing.Mobile;
 
 [Register("AppDelegate")]
@@ -440,7 +440,7 @@ public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsAppli
 
 **Android**
 
-```text
+```csharp
 using Com.Adobe.Marketing.Mobile;
 
 [Activity(Label = "TestApp", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
@@ -463,7 +463,7 @@ public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompa
     ACPSignal.RegisterExtension();
 
     // start core
-    ACPCore.Start(new CoreStartCompletionCallback());
+    ACPCore.Start(null);
 }
 ```
 {% endtab %}

--- a/getting-started/initialize-the-sdk.md
+++ b/getting-started/initialize-the-sdk.md
@@ -118,6 +118,33 @@ contextData.Add("key", "value");
 ACPCore.TrackAction("action name", contextData);
 ```
 {% endtab %}
+
+{% tab title="Xamarin" %}
+
+## C\#
+
+#### Calling TrackAction
+
+**iOS**
+
+```csharp
+var data = new NSMutableDictionary<NSString, NSString>
+{
+  ["key"] = new NSString("value")
+};
+ACPCore.TrackAction("action", data);
+```
+
+**Android**
+
+```csharp
+var data = new Dictionary<string, string>();
+data.Add("key", "value");
+ACPCore.TrackAction("action", data);
+```
+
+{% endtab %}
+
 {% endtabs %}
 
 ### Track app states and screens
@@ -232,6 +259,33 @@ dict.Add("key", "state value");
 ACPCore.TrackState("state", dict);
 ```
 {% endtab %}
+
+{% tab title="Xamarin" %}
+
+## C\#
+
+#### Calling TrackState
+
+**iOS**
+
+```csharp
+var data = new NSMutableDictionary<NSString, NSString>
+{
+  ["key"] = new NSString("value")
+};
+ACPCore.TrackState("state", data);
+```
+
+**Android**
+
+```csharp
+var data = new Dictionary<string, string>();
+data.Add("key", "value");
+ACPCore.TrackState("state", data);
+```
+
+{% endtab %}
+
 {% endtabs %}
 
 For more information, see [Mobile Core API Reference](../using-mobile-extensions/mobile-core/mobile-core-api-reference.md).

--- a/using-mobile-extensions/adobe-analytics/README.md
+++ b/using-mobile-extensions/adobe-analytics/README.md
@@ -365,7 +365,7 @@ public class MainScript : MonoBehaviour
 
 Register the Analytics extension in your app's `FinishedLaunching()` function:
 
-```text
+```csharp
 public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
   global::Xamarin.Forms.Forms.Init();
@@ -387,7 +387,7 @@ private void startCallback()
 
 Register the Analytics extension in your app's `OnCreate()` function:
 
-```text
+```csharp
 protected override void OnCreate(Bundle savedInstanceState)
 {
   base.OnCreate(savedInstanceState);
@@ -604,7 +604,7 @@ ACPCore.TrackState("State Name", contextData);
 
 #### iOS Syntax
 
-```text
+```csharp
 var contextData = new NSMutableDictionary<NSString, NSString>
 {
   ["&&events"] = new NSString("eventN:serial number")
@@ -613,7 +613,7 @@ var contextData = new NSMutableDictionary<NSString, NSString>
 
 #### iOS Example
 
-```text
+```csharp
 // create a context data dictionary and add events
 var contextData = new NSMutableDictionary<NSString, NSString>
 {
@@ -630,14 +630,14 @@ ACPCore.TrackState("State Name", contextData);
 
 #### Android Syntax
 
-```text
+```csharp
 var contextData = new Dictionary<string, string>();
 contextData.Add("&&events", "event1:12341234");
 ```
 
 #### Android Example
 
-```text
+```csharp
 // create a context data dictionary and add events
 var contextData = new Dictionary<string, string>();
 contextData.Add("&&events", "event1:12341234");
@@ -795,7 +795,7 @@ ACPCore.UpdateConfiguration(dict);
 
 **iOS**
 
-```text
+```csharp
 var config = new NSMutableDictionary<NSString, NSObject>
 {
   ["analytics.server"] = new NSString("sample.analytics.tracking.server"),
@@ -808,7 +808,7 @@ ACPCore.UpdateConfiguration(config);
 
 **Android**
 
-```text
+```csharp
 var config = new Dictionary<string, Java.Lang.Object>();
 config.Add("analytics.server", "sample.analytics.tracking.server");
 config.Add("analytics.rsids", "rsid1,rsid2");

--- a/using-mobile-extensions/adobe-analytics/analytics-api-reference.md
+++ b/using-mobile-extensions/adobe-analytics/analytics-api-reference.md
@@ -137,7 +137,7 @@ ACPAnalytics.ClearQueue();
 
 ### ClearQueue
 
-```text
+```csharp
 public static void ClearQueue ();
 ```
 
@@ -145,7 +145,7 @@ public static void ClearQueue ();
 
 **Example**
 
-```text
+```csharp
 ACPAnalytics.ClearQueue();
 ```
 {% endtab %}
@@ -310,7 +310,7 @@ ACPAnalytics.GetQueueSize(HandleAdobeGetQueueSizeCallback);
 
 **iOS Syntax**
 
-```text
+```csharp
 public unsafe static void GetQueueSize (Action<nuint> callback);
 ```
 
@@ -318,7 +318,7 @@ public unsafe static void GetQueueSize (Action<nuint> callback);
 
 **iOS Example**
 
-```text
+```csharp
 ACPAnalytics.GetQueueSize(callback => {
   Console.WriteLine("Queue size: " + callback);
 });
@@ -326,7 +326,7 @@ ACPAnalytics.GetQueueSize(callback => {
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void GetQueueSize (IAdobeCallback callback);
 ```
 
@@ -334,7 +334,7 @@ public unsafe static void GetQueueSize (IAdobeCallback callback);
 
 **Android Example**
 
-```text
+```csharp
 ACPAnalytics.GetQueueSize(new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -536,7 +536,7 @@ Retrieves the Analytics tracking identifier.
 
 **iOS Syntax**
 
-```text
+```csharp
 public unsafe static void GetTrackingIdentifier (Action<NSString> callback);
 ```
 
@@ -544,7 +544,7 @@ public unsafe static void GetTrackingIdentifier (Action<NSString> callback);
 
 **iOS Example**
 
-```text
+```csharp
 ACPAnalytics.GetTrackingIdentifier(callback => {
   Console.WriteLine("Tracking identifier: " + callback);
 });
@@ -552,7 +552,7 @@ ACPAnalytics.GetTrackingIdentifier(callback => {
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void GetTrackingIdentifier (IAdobeCallback callback);
 ```
 
@@ -560,7 +560,7 @@ public unsafe static void GetTrackingIdentifier (IAdobeCallback callback);
 
 **Android Example**
 
-```text
+```csharp
 ACPAnalytics.GetTrackingIdentifier(new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -744,7 +744,7 @@ ACPAnalytics.GetVisitorIdentifier(HandleAdobeGetVisitorIdentifierCallback);
 
 **iOS Syntax**
 
-```text
+```csharp
 public unsafe static void GetVisitorIdentifier (Action<NSString> callback);
 ```
 
@@ -752,7 +752,7 @@ public unsafe static void GetVisitorIdentifier (Action<NSString> callback);
 
 **iOS Example**
 
-```text
+```csharp
 ACPAnalytics.GetVisitorIdentifier(callback => {
   Console.WriteLine("Visitor identifier: " + callback);
 });
@@ -760,7 +760,7 @@ ACPAnalytics.GetVisitorIdentifier(callback => {
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void GetVisitorIdentifier (IAdobeCallback callback);
 ```
 
@@ -768,7 +768,7 @@ public unsafe static void GetVisitorIdentifier (IAdobeCallback callback);
 
 **Android Example**
 
-```text
+```csharp
 ACPAnalytics.GetVisitorIdentifier(new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -938,13 +938,13 @@ Regardless of how many hits are currently queued, this method forces the library
 
 **Syntax**
 
-```text
+```csharp
 public static void SendQueuedHits ();
 ```
 
 **Example**
 
-```text
+```csharp
 ACPAnalytics.SendQueuedHits();
 ```
 {% endtab %}

--- a/using-mobile-extensions/mobile-core/configuration/README.md
+++ b/using-mobile-extensions/mobile-core/configuration/README.md
@@ -58,7 +58,7 @@ ACPCore.ConfigureWithAppID("1423ae38-8385-8963-8693-28375403491d");
 {% tab title="Xamarin" %}
 #### C\#
 
-```text
+```csharp
 ACPCore.ConfigureWithAppID("1423ae38-8385-8963-8693-28375403491d");
 ```
 {% endtab %}
@@ -146,7 +146,7 @@ ACPCore.UpdateConfiguration(dict);
 
 **iOS**
 
-```text
+```csharp
  var config = new NSMutableDictionary<NSString, NSObject>
  {
    ["global.privacy"] = new NSString("optedout")
@@ -156,7 +156,7 @@ ACPCore.UpdateConfiguration(config);
 
 **Android**
 
-```text
+```csharp
 var config = new Dictionary<string, Java.Lang.Object>();
 config.Add("global.privacy", "optedout");
 ACPCore.UpdateConfiguration(config);
@@ -211,7 +211,7 @@ ACPCore.configureWithFile(inPath: filePath)
 {% tab title="Xamarin" %}
 #### C\#
 
-```text
+```csharp
 ACPCore.ConfigureWithFileInPath("absolute/path/to/exampleJSONfile.json");
 ```
 {% endtab %}

--- a/using-mobile-extensions/mobile-core/configuration/configuration-api-reference.md
+++ b/using-mobile-extensions/mobile-core/configuration/configuration-api-reference.md
@@ -62,13 +62,13 @@ ACPCore.ConfigureWithAppID("1423ae38-8385-8963-8693-28375403491d");
 {% tab title="Xamarin" %}
 #### Android Syntax
 
-```text
+```csharp
 public unsafe static void ConfigureWithAppID (string appId);
 ```
 
 #### iOS Syntax
 
-```text
+```csharp
 public static void ConfigureWithAppID (string appid);
 ```
 
@@ -190,7 +190,7 @@ Update SDK configuration
 
 **iOS**
 
-```text
+```csharp
  var config = new NSMutableDictionary<NSString, NSObject>
  {
    ["newConfigKey"] = new NSString("newConfigValue")
@@ -200,7 +200,7 @@ ACPCore.UpdateConfiguration(config);
 
 **Android**
 
-```text
+```csharp
 var config = new Dictionary<string, Java.Lang.Object>();
 config.Add("newConfigKey", "newConfigValue");
 ACPCore.UpdateConfiguration(config);
@@ -258,13 +258,13 @@ ACPCore.configureWithFile(inPath: filePath)
 {% tab title="Xamarin" %}
 #### Android Syntax
 
-```text
+```csharp
 public unsafe static void ConfigureWithFileInPath (string filepath);
 ```
 
 #### iOS Syntax
 
-```text
+```csharp
 public static void ConfigureWithFileInPath (string filepath);
 ```
 
@@ -272,7 +272,7 @@ public static void ConfigureWithFileInPath (string filepath);
 
 #### C\#
 
-```text
+```csharp
 ACPCore.ConfigureWithFileInPath("absolute/path/to/exampleJSONfile.json");
 ```
 {% endtab %}

--- a/using-mobile-extensions/mobile-core/identity/README.md
+++ b/using-mobile-extensions/mobile-core/identity/README.md
@@ -95,7 +95,7 @@ using com.adobe.marketing.mobile;
 
 After adding the iOS ACPCore NuGet package or the Android ACPIdentity NuGet package, the Identity extension can be added by this import statement
 
-```text
+```csharp
 using Com.Adobe.Marketing.Mobile;
 ```
 {% endtab %}
@@ -192,7 +192,7 @@ void Start() {
 
 Register the Identity extension in your app's `FinishedLaunching()` function:
 
-```text
+```csharp
 public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
   global::Xamarin.Forms.Forms.Init();
@@ -216,7 +216,7 @@ private void startCallback()
 
 Register the Identity extension in your app's `OnCreate()` function:
 
-```text
+```csharp
 protected override void OnCreate(Bundle savedInstanceState)
 {
   base.OnCreate(savedInstanceState);
@@ -317,7 +317,7 @@ string identityVersion = ACPIdentity.ExtensionVersion();
 {% tab title="Xamarin" %}
 #### C\#
 
-```text
+```csharp
 string identityVersion = ACPIdentity.ExtensionVersion();
 ```
 {% endtab %}
@@ -512,7 +512,7 @@ To append visitor information to the URL that is being used to open the web view
 
 **iOS**
 
-```text
+```csharp
 ACPIdentity.AppendToUrl(url, callback => {
   Console.WriteLine("Appended url: " + callback);
 });
@@ -522,7 +522,7 @@ To append visitor information to the URL that is being used to open the web view
 
 **Android**
 
-```text
+```csharp
 ACPIdentity.AppendVisitorInfoForURL("https://example.com", new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -545,7 +545,7 @@ class StringCallback : Java.Lang.Object, IAdobeCallback
 
 **iOS**
 
-```text
+```csharp
 ACPIdentity.GetUrlVariables(callback => {
   Console.WriteLine("Url variables: " + callback);
 });
@@ -553,7 +553,7 @@ ACPIdentity.GetUrlVariables(callback => {
 
 **Android**
 
-```text
+```csharp
 ACPIdentity.GetUrlVariables(new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback

--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -474,7 +474,7 @@ If the specified URL is nil or empty, it is returned as is. Otherwise, the follo
 
 **iOS Syntax**
 
-```text
+```csharp
 public unsafe static void AppendToUrl (NSUrl baseUrl, Action<NSUrl> callback);
 ```
 
@@ -483,7 +483,7 @@ public unsafe static void AppendToUrl (NSUrl baseUrl, Action<NSUrl> callback);
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void AppendVisitorInfoForURL (string baseURL, IAdobeCallback callback);
 ```
 
@@ -492,7 +492,7 @@ public unsafe static void AppendVisitorInfoForURL (string baseURL, IAdobeCallbac
 
 **iOS Example**
 
-```text
+```csharp
 ACPIdentity.AppendToUrl(url, callback => {
   Console.WriteLine("Appended url: " + callback);
 });
@@ -500,7 +500,7 @@ ACPIdentity.AppendToUrl(url, callback => {
 
 **Android Example**
 
-```text
+```csharp
 ACPIdentity.AppendVisitorInfoForURL("https://example.com", new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -522,25 +522,25 @@ class StringCallback : Java.Lang.Object, IAdobeCallback
 {% hint style="info" %}
 This API is designed to handle the following URL formats:
 
-```text
+```csharp
 scheme://authority/path?query=param#fragment
 ```
 
 In this example, the Adobe visitor data is appended as:
 
-```text
+```csharp
 scheme://authority/path?query=param&TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
 ```
 
 Similarly, URLs without a query component:
 
-```text
+```csharp
 scheme://authority/path#fragment
 ```
 
 The Adobe visitor data is appended as:
 
-```text
+```csharp
 scheme://authority/path?TS=timestamp&MCMID=ecid&MCORGID=ecorgid@AdobeOrg#fragment
 ```
 
@@ -640,13 +640,13 @@ string identityVersion = ACPIdentity.ExtensionVersion();
 
 **Syntax**
 
-```text
+```csharp
 public static string ExtensionVersion ();
 ```
 
 **Example**
 
-```text
+```csharp
 string identityVersion = ACPIdentity.ExtensionVersion();
 ```
 {% endtab %}
@@ -861,7 +861,7 @@ This ID is preserved between app upgrades, is saved and restored during the stan
 
 #### iOS Syntax
 
-```text
+```csharp
 public unsafe static void GetExperienceCloudId (Action<NSString> callback);
 ```
 
@@ -869,7 +869,7 @@ public unsafe static void GetExperienceCloudId (Action<NSString> callback);
 
 #### Android Syntax
 
-```text
+```csharp
 public unsafe static void GetExperienceCloudId (IAdobeCallback callback);
 ```
 
@@ -877,7 +877,7 @@ public unsafe static void GetExperienceCloudId (IAdobeCallback callback);
 
 #### iOS Example
 
-```text
+```csharp
 ACPIdentity.GetExperienceCloudId(callback => {
   Console.WriteLine("Experience cloud id: " + callback);
 });
@@ -885,7 +885,7 @@ ACPIdentity.GetExperienceCloudId(callback => {
 
 #### Android Example
 
-```text
+```csharp
 ACPIdentity.GetExperienceCloudId(new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -1104,7 +1104,7 @@ This API returns all customer identifiers that were previously synced with the A
 
 **iOS Syntax**
 
-```text
+```csharp
 public unsafe static void GetIdentifiers (Action<ACPMobileVisitorId[]> callback);
 ```
 
@@ -1112,7 +1112,7 @@ public unsafe static void GetIdentifiers (Action<ACPMobileVisitorId[]> callback)
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void GetIdentifiers (IAdobeCallback callback);
 ```
 
@@ -1120,7 +1120,7 @@ public unsafe static void GetIdentifiers (IAdobeCallback callback);
 
 **iOS Example**
 
-```text
+```csharp
 Action<ACPMobileVisitorId[]> callback = new Action<ACPMobileVisitorId[]>(handleCallback);
 ACPIdentity.GetIdentifiers(callback);
 
@@ -1141,19 +1141,18 @@ private void handleCallback(ACPMobileVisitorId[] ids)
 
 **Android Example**
 
-```text
+```csharp
 ACPIdentity.GetIdentifiers(new GetIdentifiersCallback());
 
 class GetIdentifiersCallback : Java.Lang.Object, IAdobeCallback
 {
-  public void Call(Java.Lang.Object visitorIDs)
+  public void Call(Java.Lang.Object retrievedIds)
   {
-    JavaList ids = null;
     System.String visitorIdsString = "[]";
-    if (visitorIDs != null)
+    if (retrievedIds != null)
     {
-      ids = (JavaList)visitorIDs;
-      if (!ids.IsEmpty)
+      var ids = GetObject<JavaList>(retrievedIds.Handle, JniHandleOwnership.DoNotTransfer);
+      if (ids != null && ids.Count > 0)
       {
         visitorIdsString = "";
         foreach (VisitorID id in ids)
@@ -1480,7 +1479,7 @@ If an error occurs while retrieving the URL string, _callback_ will be called wi
 
 **iOS Syntax**
 
-```text
+```csharp
 public unsafe static void GetUrlVariables (Action<NSString> callback);
 ```
 
@@ -1488,7 +1487,7 @@ public unsafe static void GetUrlVariables (Action<NSString> callback);
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void GetUrlVariables (IAdobeCallback callback);
 ```
 
@@ -1496,7 +1495,7 @@ public unsafe static void GetUrlVariables (IAdobeCallback callback);
 
 **iOS Example**
 
-```text
+```csharp
  ACPIdentity.GetUrlVariables(callback => {
    Console.WriteLine("Url variables: " + callback);
  });
@@ -1504,7 +1503,7 @@ public unsafe static void GetUrlVariables (IAdobeCallback callback);
 
 **Android Example**
 
-```text
+```csharp
 ACPIdentity.GetUrlVariables(new StringCallback());
 
 class StringCallback : Java.Lang.Object, IAdobeCallback
@@ -1616,7 +1615,7 @@ void Start() {
 
 Register the Identity extension in your app's `FinishedLaunching()` function:
 
-```text
+```csharp
 public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
   global::Xamarin.Forms.Forms.Init();
@@ -1634,7 +1633,7 @@ public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 
 Register the Identity extension in your app's `OnCreate()` function:
 
-```text
+```csharp
 protected override void OnCreate(Bundle savedInstanceState)
 {
   base.OnCreate(savedInstanceState);
@@ -1875,7 +1874,7 @@ ACPCore.SetAdvertisingIdentifier("ADVTID");
 
 **iOS Syntax**
 
-```text
+```csharp
 public static void SetAdvertisingIdentifier (string adId);
 ```
 
@@ -1883,7 +1882,7 @@ public static void SetAdvertisingIdentifier (string adId);
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void SetAdvertisingIdentifier (string advertisingIdentifier);
 ```
 
@@ -1891,7 +1890,7 @@ public unsafe static void SetAdvertisingIdentifier (string advertisingIdentifier
 
 **Example**
 
-```text
+```csharp
 ACPCore.SetAdvertisingIdentifier("ADVTID");
 ```
 {% endtab %}
@@ -2169,7 +2168,7 @@ ACPIdentity.SyncIdentifier("idType1", "idValue1", ACPIdentity.ACPAuthenticationS
 
 **iOS Syntax**
 
-```text
+```csharp
 public static void SyncIdentifier (string identifierType, string identifier, ACPMobileVisitorAuthenticationState authenticationState);
 ```
 
@@ -2185,7 +2184,7 @@ public static void SyncIdentifier (string identifierType, string identifier, ACP
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void SyncIdentifier (string identifierType, string identifier, VisitorID.AuthenticationState authenticationState);
 ```
 
@@ -2201,13 +2200,13 @@ public unsafe static void SyncIdentifier (string identifierType, string identifi
 
 **iOS Example**
 
-```text
+```csharp
 ACPIdentity.SyncIdentifier("idType1", "idValue1", ACPMobileVisitorAuthenticationState.Authenticated);
 ```
 
 **Android Example**
 
-```text
+```csharp
 ACPIdentity.SyncIdentifier("idType1", "idValue1", VisitorID.AuthenticationState.Authenticated);
 ```
 {% endtab %}
@@ -2374,7 +2373,7 @@ ACPIdentity.SyncIdentifiers(ids);
 
 **iOS Syntax**
 
-```text
+```csharp
 public static void SyncIdentifiers (NSDictionary identifiers);
 ```
 
@@ -2384,7 +2383,7 @@ public static void SyncIdentifiers (NSDictionary identifiers);
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void SyncIdentifiers (IDictionary<string, string> identifiers);
 ```
 
@@ -2394,7 +2393,7 @@ public unsafe static void SyncIdentifiers (IDictionary<string, string> identifie
 
 **iOS Example**
 
-```text
+```csharp
 var ids = new NSMutableDictionary<NSString, NSObject>
 {
   ["idsType1"] = new NSString("idValue1"),
@@ -2406,8 +2405,8 @@ ACPIdentity.SyncIdentifiers(ids);
 
 **Android Example**
 
-```text
-Dictionary<string, string> ids = new Dictionary<string, string>();
+```csharp
+var ids = new Dictionary<string, string>();
 ids.Add("idsType1", "idValue1");
 ids.Add("idsType2", "idValue2");
 ids.Add("idsType3", "idValue3");
@@ -2610,7 +2609,7 @@ ACPIdentity.SyncIdentifiers(ids, ACPIdentity.ACPAuthenticationState.UNKNOWN);
 
 **iOS Syntax**
 
-```text
+```csharp
 public static void SyncIdentifiers (NSDictionary identifiers, ACPMobileVisitorAuthenticationState authenticationState);
 ```
 
@@ -2625,7 +2624,7 @@ public static void SyncIdentifiers (NSDictionary identifiers, ACPMobileVisitorAu
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void SyncIdentifiers (IDictionary<string, string> identifiers, VisitorID.AuthenticationState authenticationState);
 ```
 
@@ -2640,7 +2639,7 @@ public unsafe static void SyncIdentifiers (IDictionary<string, string> identifie
 
 **iOS Example**
 
-```text
+```csharp
 var ids = new NSMutableDictionary<NSString, NSObject>
 {
   ["idsType1"] = new NSString("idValue1"),
@@ -2652,8 +2651,8 @@ ACPIdentity.SyncIdentifiers(ids, ACPMobileVisitorAuthenticationState.LoggedOut);
 
 **Android Example**
 
-```text
-Dictionary<string, string> ids = new Dictionary<string, string>();
+```csharp
+var ids = new Dictionary<string, string>();
 ids.Add("idsType1", "idValue1");
 ids.Add("idsType2", "idValue2");
 ids.Add("idsType3", "idValue3");
@@ -2825,7 +2824,7 @@ ACPIdentity.ACPAuthenticationState.LOGGED_OUT = 2;
 
 This is used to indicate the authentication state for the current `ACPMobileVisitorId`.
 
-```text
+```csharp
 ACPMobileVisitorAuthenticationState.Unknown = 0;
 ACPMobileVisitorAuthenticationState.Authenticated = 1;
 ACPMobileVisitorAuthenticationState.LoggedOut = 2;
@@ -2837,7 +2836,7 @@ ACPMobileVisitorAuthenticationState.LoggedOut = 2;
 
 This is used to indicate the authentication state for the current `VisitorID`.
 
-```text
+```csharp
 VisitorID.AuthenticationState.Unknown = 0;
 VisitorID.AuthenticationState.Authenticated = 1;
 VisitorID.AuthenticationState.LoggedOut = 2;

--- a/using-mobile-extensions/mobile-core/lifecycle/README.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/README.md
@@ -83,7 +83,7 @@ using com.adobe.marketing.mobile;
 
 After adding the iOS ACPCore NuGet package or the Android ACPLifecycle NuGet package, the Lifecycle extension can be added by this import statement
 
-```text
+```csharp
 using Com.Adobe.Marketing.Mobile;
 ```
 {% endtab %}
@@ -318,7 +318,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 1. Register the Lifecycle extension with the SDK Core by adding the following to your app's `FinishedLaunching:` delegate method:
 
-   ```text
+   ```csharp
    public override bool FinishedLaunching(UIApplication app, NSDictionary options)
    {
      ACPLifecycle.RegisterExtension();
@@ -330,7 +330,7 @@ private void OnApplicationPause(bool pauseStatus)
 
    If your iOS application supports background capabilities, your `FinishedLaunching:` method might be called when iOS launches your app in the background. If you do not want background launches to count towards your lifecycle metrics, then `LifecycleStart:` should only be called when the application state is not equal to `UIApplicationState.Background`.
 
-   ```text
+   ```csharp
    public override bool FinishedLaunching(UIApplication app, NSDictionary options)
    {
      ACPLifecycle.RegisterExtension();
@@ -347,7 +347,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 3. When launched, if your app is resuming from a backgrounded state, iOS might call your `WillEnterForeground:` delegate method. You also need to call `LifecycleStart:`, but this time you do not need all of the supporting code that you used in `FinishedLaunching:`:
 
-   ```text
+   ```csharp
    public override void WillEnterForeground(UIApplication uiApplication)
    {
      base.WillEnterForeground(uiApplication);
@@ -357,7 +357,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 4. When the app enters the background, pause Lifecycle data collection from your app's `DidEnterBackground:` delegate method:
 
-   ```text
+   ```csharp
    public override void DidEnterBackground(UIApplication uiApplication)
    {
      base.DidEnterBackground(uiApplication);
@@ -369,7 +369,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 1. Register the Lifecycle extension:
 
-   ```text
+   ```csharp
    protected override void OnCreate(Bundle savedInstanceState)
    {
      base.OnCreate(savedInstanceState);
@@ -381,7 +381,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 2. In the `onResume` function, start the lifecycle data collection:
 
-   ```text
+   ```csharp
    protected override void OnResume()
    {
      base.OnResume();
@@ -393,7 +393,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 3. In the `onPause` function, pause the lifecycle data collection:
 
-   ```text
+   ```csharp
    protected override void OnPause()
    {
      base.OnPause();
@@ -551,7 +551,10 @@ The following is a complete list of all of the metrics provided on your user's a
       <td style="text-align:left">Locale set for this device, for example, <em>en-US</em>.</td>
     </tr>
   </tbody>
-</table>If you need to programmatically update your SDK configuration, use the following information to change your Lifecycle configuration values: {% hint style="warning" %} The time that your app spends in the background is not included in the session length. {% endhint %}
+</table>
+
+If you need to programmatically update your SDK configuration, use the following information to change your Lifecycle configuration values: 
+{% hint style="warning" %} The time that your app spends in the background is not included in the session length. {% endhint %}
 
 <table>
   <thead>

--- a/using-mobile-extensions/mobile-core/lifecycle/lifecycle-api-reference.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/lifecycle-api-reference.md
@@ -8,6 +8,7 @@ To get the version of the Lifecycle extension, use the following code sample:
 
 {% tabs %}
 {% tab title="Android" %}
+
 #### Java
 
 ```java
@@ -68,7 +69,7 @@ string lifecycleVersion = ACPLifecycle.ExtensionVersion();
 {% tab title="Xamarin" %}
 ### C\#
 
-```text
+```csharp
 string lifecycleVersion = ACPLifecycle.ExtensionVersion();
 ```
 {% endtab %}
@@ -189,7 +190,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 When using iOS, the `LifecycleStart` method call must be done from the `OnActivated` method.
 
-```text
+```csharp
 public override void OnActivated(UIApplication uiApplication)
 {
   base.OnActivated(uiApplication);
@@ -201,7 +202,7 @@ public override void OnActivated(UIApplication uiApplication)
 
 When using Android, the `LifecycleStart` method call must be done from the `OnResume` method.
 
-```text
+```csharp
 protected override void OnResume()
 {
   base.OnResume();
@@ -309,7 +310,7 @@ private void OnApplicationPause(bool pauseStatus)
 
 When using iOS, the `LifecyclePause` method call must be done from the `OnResignActivation` method.
 
-```text
+```csharp
 public override void OnResignActivation(UIApplication uiApplication)
 {
   base.OnResignActivation(uiApplication);
@@ -321,7 +322,7 @@ public override void OnResignActivation(UIApplication uiApplication)
 
 When using Android, the `LifecyclePause` method call must be done from the `OnPause` method.
 
-```text
+```csharp
 protected override void OnPause()
 {
   base.OnPause();

--- a/using-mobile-extensions/mobile-core/mobile-core-api-reference.md
+++ b/using-mobile-extensions/mobile-core/mobile-core-api-reference.md
@@ -46,7 +46,7 @@ public class CoreApp extends Application {
 
 **Example**
 
-```text
+```csharp
 public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
 {
   protected override void OnCreate(Bundle savedInstanceState)
@@ -101,7 +101,7 @@ if (app != null) {
 
 **Example**
 
-```text
+```csharp
 var app = ACPCore.Application;
 if (app != null) {
     ...
@@ -281,7 +281,7 @@ ACPCore.TrackAction("action", contextData);
 
 **iOS Syntax**
 
-```text
+```csharp
 public static void TrackAction (string action, NSMutableDictionary<NSString, NSString> data);
 ```
 
@@ -290,7 +290,7 @@ public static void TrackAction (string action, NSMutableDictionary<NSString, NSS
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void TrackAction (string action, IDictionary<string, string> contextData);
 ```
 
@@ -301,7 +301,7 @@ public unsafe static void TrackAction (string action, IDictionary<string, string
 
 **iOS**
 
-```text
+```csharp
 var data = new NSMutableDictionary<NSString, NSString>
 {
   ["key"] = new NSString("value")
@@ -311,8 +311,8 @@ ACPCore.TrackAction("action", data);
 
 **Android**
 
-```text
-Dictionary<string, string> data = new Dictionary<string, string>();
+```csharp
+var data = new Dictionary<string, string>();
 data.Add("key", "value");
 ACPCore.TrackAction("action", data);
 ```
@@ -488,7 +488,7 @@ ACPCore.TrackState("state", dict);
 
 **iOS Syntax**
 
-```text
+```csharp
 public static void TrackState (string state, NSMutableDictionary<NSString, NSString> data);
 ```
 
@@ -497,7 +497,7 @@ public static void TrackState (string state, NSMutableDictionary<NSString, NSStr
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static void TrackState (string state, IDictionary<string, string> contextData);
 ```
 
@@ -508,7 +508,7 @@ public unsafe static void TrackState (string state, IDictionary<string, string> 
 
 **iOS**
 
-```text
+```csharp
 var data = new NSMutableDictionary<NSString, NSString>
 {
   ["key"] = new NSString("value")
@@ -518,8 +518,8 @@ ACPCore.TrackState("state", data);
 
 **Android**
 
-```text
-Dictionary<string, string> data = new Dictionary<string, string>();
+```csharp
+var data = new Dictionary<string, string>();
 data.Add("key", "value");
 ACPCore.TrackState("state", data);
 ```
@@ -708,13 +708,13 @@ public static void setLargeIconResourceID(int resourceID)
 
 **Syntax**
 
-```text
+```csharp
 public unsafe static void SetSmallIconResourceID (int resourceID);
 ```
 
 **Example**
 
-```text
+```csharp
 ACPCore.SetSmallIconResourceID(Resource.Mipmap.icon_round);
 ```
 
@@ -722,13 +722,13 @@ ACPCore.SetSmallIconResourceID(Resource.Mipmap.icon_round);
 
 **Syntax**
 
-```text
+```csharp
 public unsafe static void SetLargeIconResourceID (int resourceID);
 ```
 
 **Example**
 
-```text
+```csharp
  ACPCore.SetLargeIconResourceID(Resource.Mipmap.icon_round);
 ```
 {% endtab %}
@@ -914,25 +914,25 @@ The ACPCore Android extension uses the following logging modes:
 
 **iOS Syntax**
 
-```text
+```csharp
 public static ACPMobileLogLevel LogLevel { get, set }
 ```
 
 **iOS Example**
 
-```text
+```csharp
 ACPCore.LogLevel = ACPMobileLogLevel.Verbose;
 ```
 
 **Android Syntax**
 
-```text
+```csharp
 public unsafe static LoggingMode LogLevel { get, set }
 ```
 
 **Android Example**
 
-```text
+```csharp
 ACPCore.LogLevel = LoggingMode.Verbose;
 ```
 {% endtab %}
@@ -1016,7 +1016,7 @@ ACPCore.ACPMobileLogLevel logLevel = ACPCore.GetLogLevel();
 
 #### getLogLevel
 
-```text
+```csharp
 var logLevel = ACPCore.LogLevel;
 ```
 {% endtab %}
@@ -1128,7 +1128,7 @@ const VERBOSE = "ACP_LOG_LEVEL_VERBOSE";
 
 The log messages from the Adobe Experience SDK are printed to the Log facility and use a common format that contains the tag `AdobeExperienceSDK`. For example, if logging an error message using `ACPCore.Log()`, the api call and logging output on Xamarin iOS look like
 
-```text
+```csharp
 ACPCore.Log(ACPMobileLogLevel.Error, "xamarin tag", "xamarin message");
 ```
 
@@ -1138,7 +1138,7 @@ ACPCore.Log(ACPMobileLogLevel.Error, "xamarin tag", "xamarin message");
 
 On Xamarin Android, the api call and logging output are
 
-```text
+```csharp
 ACPCore.Log(LoggingMode.Error, "xamarin tag", "xamarin message");
 ```
 
@@ -1226,13 +1226,13 @@ ACPCore.setAppGroup("app-group-id")
 
 **Syntax**
 
-```text
+```csharp
 public static void SetAppGroup (string appGroup);
 ```
 
 **Example**
 
-```text
+```csharp
 ACPCore.SetAppGroup("app_group");
 ```
 {% endtab %}
@@ -1361,7 +1361,7 @@ ACPCore.getPrivacyStatus { (privacyStatus, error) in
 
 This class provides the interface to receive results when the async APIs perform the requested action.
 
-```text
+```csharp
 public interface IAdobeCallback : IJavaObject, IDisposable, IJavaPeerable
 {
     void Call (Java.Lang.Object p0);
@@ -1372,7 +1372,7 @@ public interface IAdobeCallback : IJavaObject, IDisposable, IJavaPeerable
 
 This class provides the interface to receive results or an error when the async APIs perform the requested action. When using this class, if the request cannot be completed within the default timeout or an unexpected error occurs, the request is aborted and the _fail_ method is called with the corresponding _AdobeError_.
 
-```text
+```csharp
 public interface IAdobeCallbackWithError : IAdobeCallback, IJavaObject, IDisposable, IJavaPeerable
 {
     void Fail (AdobeError p0);
@@ -1390,7 +1390,7 @@ Errors which may be passed to an AdobeCallbackWithError:
 
 **Example**
 
-```text
+```csharp
 ACPCore.GetPrivacyStatus(new AdobeCallbackWithError());
 
 class AdobeCallbackWithError : Java.Lang.Object, IAdobeCallbackWithError
@@ -1442,7 +1442,7 @@ Errors which may be passed to a completion handler callback from any API which u
 
 **Example**
 
-```text
+```csharp
 ACPCore.GetPrivacyStatusWithCompletionHandler((privacyStatus, error) => {
   if (error != null)
   {

--- a/using-mobile-extensions/mobile-core/signals/README.md
+++ b/using-mobile-extensions/mobile-core/signals/README.md
@@ -109,7 +109,7 @@ using com.adobe.marketing.mobile;
 
 After adding the iOS ACPCore NuGet package or the Android ACPSignal NuGet package, the Signal extension can be added by this import statement
 
-```text
+```csharp
 using Com.Adobe.Marketing.Mobile;
 ```
 {% endtab %}
@@ -216,7 +216,7 @@ void Start()
 
 Register the Signal extension with the SDK Core by adding the following to your app's `FinishedLaunching:` delegate method:
 
-```text
+```csharp
 public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
   ACPSignal.RegisterExtension();
@@ -237,7 +237,7 @@ private void startCallback()
 
 Register the Signal extension with the SDK Core by adding the following to your app's `OnCreate:` method:
 
-```text
+```csharp
 protected override void OnCreate(Bundle savedInstanceState)
 {
   base.OnCreate(savedInstanceState);

--- a/using-mobile-extensions/mobile-core/signals/signal-api-reference.md
+++ b/using-mobile-extensions/mobile-core/signals/signal-api-reference.md
@@ -68,7 +68,7 @@ string signalVersion = ACPSignal.ExtensionVersion();
 {% tab title="Xamarin" %}
 ### C\#
 
-```text
+```csharp
 string signalVersion = ACPSignal.ExtensionVersion();
 ```
 {% endtab %}


### PR DESCRIPTION
- update xamarin code samples to use `csharp` code type
- cleanup some confusing code samples
- add missing samples in the "getting started" section
- fix hint formatting issue in the lifecycle README