### PR TITLE
Lifecycle event correction.

### DIFF
--- a/using-mobile-extensions/mobile-core/lifecycle/README.md
+++ b/using-mobile-extensions/mobile-core/lifecycle/README.md
@@ -361,7 +361,7 @@ private void OnApplicationPause(bool pauseStatus)
    public override void DidEnterBackground(UIApplication uiApplication)
    {
      base.DidEnterBackground(uiApplication);
-     ACPCore.LifecycleStart(null);
+     ACPCore.LifecyclePause();
    }
    ```
 


### PR DESCRIPTION
Expected:
``` csharp
public override void DidEnterBackground(UIApplication uiApplication)
{
     base.DidEnterBackground(uiApplication);
     ACPCore.LifecyclePause();
}
```

Current:
``` csharp
public override void DidEnterBackground(UIApplication uiApplication)
{
     base.DidEnterBackground(uiApplication);
     ACPCore.LifecycleStart(null);
}
```