### PR TITLE
Add AppTrackingTransparency example to Identity docs

### DIFF
--- a/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
+++ b/using-mobile-extensions/mobile-core/identity/identity-api-reference.md
@@ -1728,6 +1728,10 @@ public void onResume() {
 Retrieve the Identifier for Advertising \(IDFA\) from Apple APIs only if you are using an ad service. If you retrieve IDFA, and are not using it properly, your app might be rejected.
 {% endhint %}
 
+{% hint style="info" %}
+Since iOS 14+, applications must use the [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency) framework for requesting a user's authorization before using the Identifier for Advertising \(IDFA)\.  The following is an implementaiton example of how to suport your application running on different versions of iOS.
+{% endhint %}
+
 {% hint style="warning" %}
 This is just an implementation example. For more information about IDFA and how to handle them correctly in your mobile application, see [Apple developer documentation about IDFA](https://developer.apple.com/documentation/adsupport/asidentifiermanager)
 {% endhint %}
@@ -1748,17 +1752,62 @@ This is just an implementation example. For more information about IDFA and how 
 
 ```objectivec
 #import <AdSupport/ASIdentifierManager.h>
+#import <AppTrackingTransparency/ATTrackingManager.h>
 ...
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+-   ...
+-   
+    if (@available(iOS 14, *)) {
+        [self setAdvertisingIdentitiferUsingTrackingManager];
+    } else {
+        // fallback to earlier versions
+        [self setAdvertisingIdentifierUsingIdentifierManager];
+    }
+
+}
+
+- (void) setAdvertisingIdentifierUsingIdentifierManager {
+    // setup the advertising identifier
     NSString *idfa = nil;
     if ([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
         idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     } else {
-        [ACPCore log:ACPMobileLogLevelDebug tag:@"AppDelegateExample" message:@"Advertising Tracking is disabled by the user, cannot process the advertising identifier"];
+        [ACPCore log:ACPMobileLogLevelDebug
+                 tag:@"AppDelegateExample"
+             message:@"Advertising Tracking is disabled by the user, cannot process the advertising identifier"];
     }
     [ACPCore setAdvertisingIdentifier:idfa];
-    ...
+    
+}
+
+- (void) setAdvertisingIdentitiferUsingTrackingManager API_AVAILABLE(ios(14)) {
+    [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:
+    ^(ATTrackingManagerAuthorizationStatus status){
+        NSString *idfa = nil;
+        switch(status) {
+            case ATTrackingManagerAuthorizationStatusAuthorized:
+                idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+                break;
+            case ATTrackingManagerAuthorizationStatusDenied:
+                [ACPCore log:ACPMobileLogLevelDebug
+                         tag:@"AppDelegateExample"
+                     message:@"Advertising Tracking is denied by the user, cannot process the advertising identifier"];
+                break;
+            case ATTrackingManagerAuthorizationStatusNotDetermined:
+                [ACPCore log:ACPMobileLogLevelDebug
+                         tag:@"AppDelegateExample"
+                     message:@"Advertising Tracking is not determined, cannot process the advertising identifier"];
+                break;
+            case ATTrackingManagerAuthorizationStatusRestricted:
+                [ACPCore log:ACPMobileLogLevelDebug
+                         tag:@"AppDelegateExample"
+                     message:@"Advertising Tracking is restricted by the user, cannot process the advertising identifier"];
+                break;
+        }
+        
+        [ACPCore setAdvertisingIdentifier:idfa];
+    }];
 }
 ```
 
@@ -1766,17 +1815,56 @@ This is just an implementation example. For more information about IDFA and how 
 
 ```swift
 import AdSupport
+import AppTrackingTransparency
 ...
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    var idfa:String = "";
-    if (ASIdentifierManager.shared().isAdvertisingTrackingEnabled) {
-        idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString;
-    } else {
-        ACPCore.log(ACPMobileLogLevel.debug, tag: "AppDelegateExample", message: "Advertising Tracking is disabled by the user, cannot process the advertising identifier");
-    }
-    ACPCore.setAdvertisingIdentifier(idfa);
     ...
+    if #available(iOS 14, *) {
+       setAdvertisingIdentitiferUsingTrackingManager()
+    } else {
+       // Fallback on earlier versions
+       setAdvertisingIdentifierUsingIdentifierManager()
+    }
+    
+}
+
+func setAdvertisingIdentifierUsingIdentifierManager() {
+    var idfa:String = "";
+        if (ASIdentifierManager.shared().isAdvertisingTrackingEnabled) {
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString;
+        } else {
+            ACPCore.log(ACPMobileLogLevel.debug,
+                        tag: "AppDelegateExample",
+                        message: "Advertising Tracking is disabled by the user, cannot process the advertising identifier.");
+        }
+        ACPCore.setAdvertisingIdentifier(idfa);
+}
+    
+@available(iOS 14, *)
+func setAdvertisingIdentitiferUsingTrackingManager() {
+    ATTrackingManager.requestTrackingAuthorization { (status) in
+        var idfa: String = "";
+                        
+        switch (status) {
+        case .authorized:
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+        case .denied:
+            ACPCore.log(.debug,
+                        tag: "AppDelegateExample",
+                        message: "Advertising Tracking is denied by the user, cannot process the advertising identifier.")
+        case .notDetermined:
+            ACPCore.log(.debug,
+                        tag: "AppDelegateExample",
+                        message: "Advertising Tracking is not determined, cannot process the advertising identifier.")
+        case .restricted:
+            ACPCore.log(.debug,
+                        tag: "AppDelegateExample",
+                        message: "Advertising Tracking is restricted by the user, cannot process the advertising identifier.")
+        }
+                                    
+        ACPCore.setAdvertisingIdentifier(idfa)
+    }
 }
 ```
 {% endtab %}


### PR DESCRIPTION
Add AppTrackingTransparency example to Identity setAdvertisingIdentifier().

In iOS 14, the existing ASIdentifierManger.isAdvertisingTrackingEnabled is deprecated and is replaced by the AppTrackingTransparency framework. As we currently have a code example on how to get the advertising identifier using ASIdentifierManager, I'm adding an example on using AppTrackingTransparency for app running on iOS 14.