### PR TITLE
Merge swift core API descriptions to the main docs

### DIFF
--- a/foundation-extensions/mobile-core/configuration/configuration-api-reference.md
+++ b/foundation-extensions/mobile-core/configuration/configuration-api-reference.md
@@ -15,7 +15,7 @@ String coreExtensionVersion = MobileCore.extensionVersion();
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Obj-C" %}
 **Objective C**
 
 ```objectivec
@@ -95,7 +95,32 @@ MobileCore.configureWithAppId("1423ae38-8385-8963-8693-28375403491d");
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+#### Syntax
+
+```swift
+static func configureWith(appId: String)
+```
+
+#### Example
+
+#### Objective-C
+
+```objectivec
+[AEPMobileCore configureWithAppId: @"1423ae38-8385-8963-8693-28375403491d"];
+```
+
+#### Swift
+
+```swift
+MobileCore.configureWith(appId: "1423ae38-8385-8963-8693-28375403491d")
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
+
 #### Syntax
 
 ```objectivec
@@ -189,7 +214,36 @@ MobileCore.updateConfiguration(data);
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+### updateConfiguration
+
+#### Syntax
+
+```objectivec
+@objc(updateConfiguration:)
+static func updateConfigurationWith(configDict: [String: Any])
+```
+
+#### Example
+
+#### Objective-C
+
+```objectivec
+NSDictionary *updatedConfig = @{@"global.privacy":@"optedout"};
+[AEPMobileCore updateConfiguration:updatedConfig];
+```
+
+#### Swift
+
+```swift
+let updatedConfig = ["global.privacy":"optedout"]
+MobileCore.updateConfigurationWith(configDict: updatedConfig)
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 ### updateConfiguration
 
 #### Syntax
@@ -305,7 +359,34 @@ MobileCore.configureWithFileInPath("absolute/path/to/exampleJSONfile.json");
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+#### Syntax
+
+```swift
+static func configureWith(filePath: String)
+```
+
+#### Example
+
+**Objective-C**
+
+```objectivec
+NSString *filePath = [[NSBundle mainBundle] pathForResource:@"ExampleJSONFile"ofType:@"json"];
+[AEPMobileCore configureWithFilePath:filePath];
+```
+
+**Swift**
+
+```swift
+let filePath = Bundle.main.path(forResource: "ExampleJSONFile", ofType: "json")
+MobileCore.configureWith(filePath: filePath)
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
+
 #### Syntax
 
 ```objectivec

--- a/foundation-extensions/mobile-core/lifecycle/lifecycle-api-reference.md
+++ b/foundation-extensions/mobile-core/lifecycle/lifecycle-api-reference.md
@@ -15,7 +15,7 @@ String lifecycleExtensionVersion = Lifecycle.extensionVersion();
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Obj-C" %}
 **Objective C**
 
 ```objectivec
@@ -108,7 +108,39 @@ This method should be called from the Activity onResume method.
 {% endhint %}
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+#### Objective-C
+
+**Syntax**
+
+```swift
+@objc(lifecycleStart:)
+static func lifecycleStart(additionalContextData: [String: Any]?)
+```
+
+**Example**
+
+```text
+[AEPMobileCore lifecycleStart:nil];
+```
+
+If you need to collect additional lifecycle data:
+
+```text
+[AEPMobileCore lifecycleStart:@{@"contextDataKey": @"contextDataVal"}];
+```
+
+#### Swift
+
+```swift
+MobileCore.lifecycleStart(additionalContextData: ["contextDataKey": "contextDataVal"])
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
+
 #### Objective-C
 
 **Syntax**
@@ -234,7 +266,32 @@ MobileCore.lifecyclePause();
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+#### Objective-C
+
+**Syntax**
+
+```swift
+@objc(lifecyclePause)
+static func lifecyclePause()
+```
+
+**Example**
+
+```text
+[AEPMobileCore lifecyclePause];
+```
+
+#### Swift
+
+```swift
+MobileCore.lifecyclePause()
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 #### Objective-C
 
 **Syntax**

--- a/foundation-extensions/mobile-core/mobile-core-api-reference.md
+++ b/foundation-extensions/mobile-core/mobile-core-api-reference.md
@@ -146,7 +146,50 @@ MobileCore.trackAction("loginClicked", additionalContextData);
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+**Objective-C**
+
+### trackAction
+
+**Syntax**
+
+```swift
+@objc(trackAction:data:)
+static func track(action: String?, data: [String: Any]?)
+```
+
+* _action_ contains the name of the action to track.
+* _contextData_ contains the context data to attach on this hit.
+
+**Example**
+
+```objectivec
+ [AEPMobileCore trackAction:@"action name" data:@{@"key":@"value"}];
+```
+
+**Swift**
+
+### trackAction
+
+**Syntax**
+
+```swift
+static func track(action: String?, data: [String: Any]?)
+```
+
+* _action_ contains the name of the action to track.
+* _contextData_ contains the context data to attach on this hit.
+
+**Example**
+
+```swift
+MobileCore.track(action: "action name", data: ["key": "value"])
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 **Objective-C**
 
 ### trackAction
@@ -353,7 +396,50 @@ MobileCore.trackState("homePage", additionalContextData);
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+**Objective-C**
+
+### trackState
+
+**Syntax**
+
+```swift
+@objc(trackState:data:)
+static func track(state: String?, data: [String: Any]?)
+```
+
+* _state_ contains the name of the state to track.
+* _contextData_ contains the context data to attach on this hit.
+
+**Example**
+
+```objectivec
+ [AEPMobileCore trackState:@"state name" data:@{@"key":@"value"}];
+```
+
+**Swift**
+
+### trackState
+
+**Syntax**
+
+```swift
+static func track(state: String?, data: [String: Any]?)
+```
+
+* _state_ contains the name of the state to track.
+* _contextData_ contains the context data to attach on this hit.
+
+**Example**
+
+```swift
+MobileCore.track(state: "state name", data: ["key": "value"])
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 **Objective-C**
 
 ### trackState
@@ -557,7 +643,46 @@ MobileCore.collectPII(data);
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+**Objective-C**
+
+### collectPii
+
+**Syntax**
+
+```swift
+@objc(collectPii:)
+public static func collectPii(_ data: [String: Any])
+```
+
+**Example**
+
+```objectivec
+[AEPMobileCore collectPii:data:@{@"key1" : @"value1",
+                           @"key2" : @"value2"
+                           }];
+```
+
+**Swift**
+
+### collectPii
+
+**Syntax**
+
+```swift
+public static func collectPii(_ data: [String: Any])
+```
+
+**Example**
+
+```objectivec
+MobileCore.collectPii(["key1" : "value1","key2" : "value2"]);
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 **Objective-C**
 
 ### collectPii
@@ -609,7 +734,60 @@ If the Analytics extension is enabled in your SDK, collecting this launch data r
 Coming soon
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+**Objective-C**
+
+This method should be called to support the following use cases:
+
+* Tracking Deep Link click-throughs
+  * From `application:didFinishLaunchingWithOptions`
+  * Extract `userInfo` from `UIApplicationLaunchOptionsURLKey`
+* Tracking Push Message click-through
+  * From `application:didReceiveRemoteNotification:fetchCompletionHandler:`
+
+#### collectLaunchInfo
+
+**Syntax**
+
+```text
+@objc(collectLaunchInfo:)
+public static func collectLaunchInfo(_ userInfo: [String: Any])
+```
+
+**Example**
+
+```text
+ [AEPMobileCore collectLaunchInfo:launchOptions];
+```
+
+**Swift**
+
+This method should be called to support the following use cases:
+
+* Tracking Deep Link click-throughs
+  * From `application(_:didFinishLaunchingWithOptions:)`
+  * Extract `userInfo` from `url: UIApplication.LaunchOptionsKey`
+* Tracking Push Message click-through
+  * From `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
+
+#### collectLaunchInfo
+
+**Syntax**
+
+```swift
+public static func collectLaunchInfo(_ userInfo: [String: Any])
+```
+
+**Example**
+
+```swift
+AEPCore.collectLaunchInfo(userInfo)
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 **Objective-C**
 
 This method should be called to support the following use cases:
@@ -706,7 +884,48 @@ MobileCore.getSdkIdentities(new AdobeCallback<String>() {
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+#### Objective-C
+
+### getSdkIdentities
+
+#### Syntax
+
+```objectivec
+@objc(getSdkIdentities:)
+static func getSdkIdentities(completion: @escaping (String?, Error?) -> Void)
+```
+
+* _callback_ is invoked with the SDK identities as a JSON string.
+* _completionHandler_ is invoked with the SDK identities as a JSON string, or _error_ if an unexpected error occurs or the request times out. The default timeout is 1000ms.
+
+#### Example
+
+**Objective-C**
+
+```objectivec
+[AEPMobileCore getSdkIdentities:^(NSString * _Nullable content, NSError * _Nullable error) {
+    if (error) {
+      // handle error here
+    } else {
+      // handle the retrieved identities
+    }
+}];
+```
+
+**Swift**
+
+```swift
+MobileCore.getSdkIdentities { (content, error) in
+    // handle completion
+}
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
+
 #### Objective-C
 
 ### getSdkIdentities
@@ -859,7 +1078,44 @@ MobileCore.setLogLevel(LoggingMode.VERBOSE);
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS — Swift" %}
+
+**Objective C**
+
+#### setLogLevel
+
+**Syntax**
+
+```swift
+@objc(setLogLevel:)
+public static func setLogLevel(_ level: LogLevel)
+```
+
+**Example**
+
+```text
+[AEPMobileCore setLogLevel: AEPLogLevelTrace];
+```
+
+**Swift**
+
+#### setLogLevel
+
+**Syntax**
+
+```swift
+public static func setLogLevel(_ level: LogLevel)
+```
+
+**Example**
+
+```swift
+MobileCore.setLogLevel(.trace)
+```
+
+{% endtab %}
+
+{% tab title="iOS — Obj-C" %}
 **Objective C**
 
 #### setLogLevel


### PR DESCRIPTION
@praschetan I saw you have merged AEPUserProfile API doc to the main doc with a new tab - `iOS - Swift`, I just did the same thing for core extensions. With this change, I can put some links in the Swift Migration Guide, then customers can navigate to the API details of the AEP SDK. 