### PR TITLE
Update tab names in Edge Identity and Consent install instructions.

### DIFF
--- a/foundation-extensions/consent-for-edge-network/README.md
+++ b/foundation-extensions/consent-for-edge-network/README.md
@@ -32,11 +32,14 @@ The Adobe Experience Platform Consent mobile extension enables consent preferenc
 2. Import the Mobile Core and Edge extensions in your application class.
 
    ```java
-    import com.adobe.marketing.mobile.*;
+    import com.adobe.marketing.mobile.MobileCore;
+    import com.adobe.marketing.mobile.Edge;
+    import com.adobe.marketing.mobile.edge.identity.Identity;
+    import com.adobe.marketing.mobile.edge.consent.Consent;
    ```
-{% endtab %}
+   {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS (AEP 3.x)" %}
 1. Add the Mobile Core and Edge extensions to your project using Cocoapods. Add following pods in your `Podfile`:
 
    ```swift
@@ -71,6 +74,13 @@ import AEPEdgeConsent
 @import AEPEdgeConsent;
 ```
 {% endtab %}
+
+{% tab title="iOS (ACP 2.x)" %}
+
+This extension is built on the AEPCore (3.x) and it is not compatible with ACPCore (2.x). Please follow [the guide for migrating to the Swift AEPCore](https://aep-sdks.gitbook.io/docs/resources/migrate-to-swift).
+
+{% endtab %}
+
 {% endtabs %}
 
 ### Register Edge extensions with Mobile Core
@@ -105,7 +115,7 @@ public class MobileApp extends Application {
 ```
 {% endtab %}
 
-{% tab title="iOS" %}
+{% tab title="iOS AEP(3.x)" %}
 ### Swift
 
 ```swift

--- a/foundation-extensions/consent-for-edge-network/README.md
+++ b/foundation-extensions/consent-for-edge-network/README.md
@@ -29,7 +29,7 @@ The Adobe Experience Platform Consent mobile extension enables consent preferenc
    implementation 'com.adobe.marketing.mobile:edgeconsent:1.+'
    ```
 
-2. Import the Mobile Core and Edge extensions in your application class.
+2. Import the Mobile Core and Edge extensions in your Application class.
 
    ```java
     import com.adobe.marketing.mobile.MobileCore;

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -32,7 +32,7 @@ The following instructions are for configuring an application using Adobe Experi
    implementation 'com.adobe.marketing.mobile:edgeidentity:1.+'
    ```
 
-2. Import the Mobile Core and Edge extensions in your application class.
+2. Import the Mobile Core and Edge extensions in your Application class.
 
    ```java
     import com.adobe.marketing.mobile.MobileCore;

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -35,10 +35,16 @@ The following instructions are for configuring an application using Adobe Experi
 2. Import the Mobile Core and Edge extensions in your application class.
 
    ```java
-    import com.adobe.marketing.mobile.*;
+    import com.adobe.marketing.mobile.MobileCore;
+    import com.adobe.marketing.mobile.Edge;
+    import com.adobe.marketing.mobile.edge.identity.Identity;
    ```
 
-3. Add the Mobile Core and Edge extensions to your project using CocoaPods. Add following pods in your `Podfile`:
+{% endtab %}
+
+{% tab title="iOS (AEP 3.x)" %}
+
+1. Add the Mobile Core and Edge extensions to your project using CocoaPods. Add following pods in your `Podfile`:
 
    ```swift
    use_frameworks!
@@ -49,10 +55,8 @@ The following instructions are for configuring an application using Adobe Experi
    end
    ```
 
-4. Import the Mobile Core and Edge libraries:
-{% endtab %}
+2. Import the Mobile Core and Edge libraries:
 
-{% tab title="iOS — Swift" %}
 ### Swift
 
 ```swift
@@ -71,6 +75,13 @@ import AEPEdgeIdentity
 @import AEPEdgeIdentity;
 ```
 {% endtab %}
+
+{% tab title="iOS (ACP 2.x)" %}
+
+This extension is built on the AEPCore (3.x) and it is not compatible with ACPCore (2.x). Please follow [the guide for migrating to the Swift AEPCore](https://aep-sdks.gitbook.io/docs/resources/migrate-to-swift).
+
+{% endtab %}
+
 {% endtabs %}
 
 ### Register the Identity extension with Mobile Core
@@ -100,7 +111,7 @@ public class MobileApp extends Application {
 ```
 {% endtab %}
 
-{% tab title="iOS — Swift" %}
+{% tab title="iOS (AEP 3.x)" %}
 ### Swift
 
 ```swift


### PR DESCRIPTION
Updates Identity for Edge Network and Consent for Edge Network install instructions with standard iOS tab names for "AEP (3.x)" and "ACP (2.x)".
Removes use of wildcard when importing Android packages.