### PR TITLE
Release notes for iOS AEP Core v3.5.0, Edge v1.4.0, Consent v1.0.1

### DIFF
--- a/foundation-extensions/consent-for-edge-network/release-notes-1.md
+++ b/foundation-extensions/consent-for-edge-network/release-notes-1.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## April 8, 2022
+
+### iOS AEPEdgeConsent 1.0.1
+
+* Updates timestamp in Consent requests to use fractional seconds.
+
 ## March 11, 2022
 
 ### Android Consent 1.0.1

--- a/foundation-extensions/experience-platform-extension/release-notes.md
+++ b/foundation-extensions/experience-platform-extension/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## April 8, 2022
+
+### iOS AEPEdge 1.4.0
+
+* Updates timestamp in Experience Events to use fractional seconds.
+* Deprecates APIs `XDMFormatters.dateToISO8601String` and `XDMFormatters.dateToFullDateString`. Use the `Date` extension methods `getISO8601UTCDateWithMilliseconds` and `getISO8601FullDate` instead, provided by the AEPServices module within the AEPCore extension. 
+
 ## April 1, 2022
 
 ### Adobe Experience Platform Edge Network Launch extension v1.1.9

--- a/foundation-extensions/mobile-core/mobile-core-release-notes.md
+++ b/foundation-extensions/mobile-core/mobile-core-release-notes.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## April 8, 2022
+
+### iOS AEPCore 3.5.0
+
+* Adds two APIs to `Date+Format` class. Method `getISO8601UTCDateWithMilliseconds` formats a Date to string as with fractional seconds and UTC time zone, while `getISO8601FullDate` formats a Date to string with date without time using the local time zone.
+* Lifecycle foreground and background events for Edge Network now format timestamps with fractional seconds and UTC time zone.
+* Updates the timestamp format for rule token `~timestampp` with fractional seconds and UTC time zone. This rule token is used to set the mobile property data element "Adobe Experience Platform Timestamp".
+* Improves Signal logging by treating all 2xx network responses as success.
+* Fixes bug where dispatched events failed due to use of single quotes in name.
+* Fixes format of push token string by uppercasing characters.
+
 ## March 11, 2022
 
 ### Android Core 1.10.1

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -4,6 +4,26 @@ description: Release notes and change logs for the Adobe Experience Platform Mob
 
 # Release notes
 
+## April 8, 2022
+
+### iOS AEPCore 3.5.0
+
+* Adds two APIs to `Date+Format` class. Method `getISO8601UTCDateWithMilliseconds` formats a Date to string as with fractional seconds and UTC time zone, while `getISO8601FullDate` formats a Date to string with date without time using the local time zone.
+* Lifecycle foreground and background events for Edge Network now format timestamps with fractional seconds and UTC time zone.
+* Updates the timestamp format for rule token `~timestampp` with fractional seconds and UTC time zone. This rule token is used to set the mobile property data element "Adobe Experience Platform Timestamp".
+* Improves Signal logging by treating all 2xx network responses as success.
+* Fixes bug where dispatched events failed due to use of single quotes in name.
+* Fixes format of push token string by uppercasing characters.
+
+### iOS AEPEdge 1.4.0
+
+* Updates timestamp in Experience Events to use fractional seconds.
+* Deprecates APIs `XDMFormatters.dateToISO8601String` and `XDMFormatters.dateToFullDateString`. Use the `Date` extension methods `getISO8601UTCDateWithMilliseconds` and `getISO8601FullDate` instead, provided by the AEPServices module within the AEPCore extension. 
+
+### iOS AEPEdgeConsent 1.0.1
+
+* Updates timestamp in Consent requests to use fractional seconds.
+
 ## April 1, 2022
 
 ### iOS AEPEdgeIdentity 1.0.1


### PR DESCRIPTION
Release notes for:

- iOS AEPCore 3.5.0
- iOS AEPEdge 1.4.0
- iOS AEPEdgeConsent 1.0.1
