### PR TITLE
Edge identity set advertising identitfier api update

### DIFF
--- a/foundation-extensions/consent-for-edge-network/README.md
+++ b/foundation-extensions/consent-for-edge-network/README.md
@@ -12,6 +12,10 @@ The Adobe Experience Platform Consent mobile extension enables consent preferenc
 
 ![AEP Consent extension configuration](../../.gitbook/assets/mobile-edge-consent-launch-configuration.png)
 
+{% hint style="info" %}
+In order to collect and use the Consents and Preferences data type collected by this extension, follow the guide on [creating a schema and dataset for ingestion](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html#ingest).
+{% endhint %}
+
 ## Add the AEP Consent extension to your app
 
 ### Download and import the Consent extension

--- a/foundation-extensions/consent-for-edge-network/README.md
+++ b/foundation-extensions/consent-for-edge-network/README.md
@@ -13,7 +13,7 @@ The Adobe Experience Platform Consent mobile extension enables consent preferenc
 ![AEP Consent extension configuration](../../.gitbook/assets/mobile-edge-consent-launch-configuration.png)
 
 {% hint style="info" %}
-In order to collect and use the Consents and Preferences data type collected by this extension, follow the guide on [creating a schema and dataset for ingestion](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html#ingest).
+In order to ingest and use the data collected by this extension, follow the guide on [ingesting data using the Consents and Preferences data type](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html#ingest).
 {% endhint %}
 
 ## Add the AEP Consent extension to your app

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -173,9 +173,8 @@ Ad tracking enabled - when the new value sent to the API is:
 - A valid UUID string (example: `"a127a99e-50be-4d87-bf6f-6ab9541c105b"`)
 
 Process:
-1. Updates the `IdentityMap` in memory/persistence with the new value for IDFA/GAID. For more details see the [standard Identity namespaces](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html#standard).
-2. Updates the XDM shared state with the new `IdentityMap`.
-3. Sends a consent update event with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured).
+1. Updates the client side XDM `IdentityMap` with the new value for IDFA/GAID, and it will be sent with any future [XDM Experience events](../experience-platform-extension/xdm-experience-events.md). For more details on these namespaces see the [standard Identity namespaces](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html#standard). 
+2. Sends a [consent update event](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html) with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured).
 
 Ad tracking disabled - Given a valid ad ID already exists in the `IdentityMap`, and the new value  sent to the API is: 
 - `null`/`nil`
@@ -183,8 +182,7 @@ Ad tracking disabled - Given a valid ad ID already exists in the `IdentityMap`, 
 - All-zeros string (`"00000000-0000-0000-0000-000000000000"`)  
 
 Process:
-1. Removes the ad ID from the `IdentityMap` in memory/persistence.
-2. Updates the XDM shared state with the new `IdentityMap`.
-3. Sends a consent update event with ad ID consent preferences set to `no` (only when the Edge Consent extension is registered and properly configured).
+1. Removes the ad ID from the client side XDM `IdentityMap`, and it will not be sent with any future [XDM Experience events](../experience-platform-extension/xdm-experience-events.md).
+2. Sends a [consent update event](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html) with ad ID consent preferences set to `no` (only when the Edge Consent extension is registered and properly configured).
 
 No operations are executed when no changes are detected between the previously stored and new ad ID value.

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -176,7 +176,7 @@ Process:
 1. Updates the client side XDM `IdentityMap` with the new value for IDFA/GAID, and it will be sent with any future [XDM Experience events](../experience-platform-extension/xdm-experience-events.md). For more details on these namespaces see the [standard Identity namespaces](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html#standard). 
 2. Sends a [consent update event](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html) with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured).
 
-Ad tracking disabled - Given a valid ad ID already exists in the `IdentityMap`, and the new value  sent to the API is: 
+Ad tracking disabled - Given a valid ad ID already exists in the `IdentityMap`, and the new value sent to the API is: 
 - `null`/`nil`
 - Empty string (`""`)
 - All-zeros string (`"00000000-0000-0000-0000-000000000000"`)  

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -20,6 +20,10 @@ The Adobe Experience Platform Identity mobile extension enables identity managem
 The following instructions are for configuring an application using Adobe Experience Platform Edge mobile extensions. If an application will include both Edge Network and Adobe Solution extensions, both the Identity for Edge Network and Identity for Experience Cloud ID Service extensions are required. Find more details in the [frequently asked questions](identity-faq.md).
 {% endhint %}
 
+{% hint style="info" %}
+When using AEP Consent for Edge do we currently specify what field group you need to include to your profile schema for consent in our docs?
+{% endhint %}
+
 {% tabs %}
 {% tab title="Android" %}
 

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -21,7 +21,7 @@ The following instructions are for configuring an application using Adobe Experi
 {% endhint %}
 
 {% hint style="info" %}
-When using AEP Consent for Edge do we currently specify what field group you need to include to your profile schema for consent in our docs?
+See the setup guide for [Adobe Experience Platform Consent](../consent-for-edge-network/README.md) for instructions on setting up the extension and profile schema for proper usage.
 {% endhint %}
 
 {% tabs %}

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -21,7 +21,7 @@ The following instructions are for configuring an application using Adobe Experi
 {% endhint %}
 
 {% hint style="info" %}
-See the setup guide for [Adobe Experience Platform Consent](../consent-for-edge-network/README.md) for instructions on setting up the extension and profile schema for proper usage.
+When using the [`setAdvertisingIdentifier`](./api-reference.md#setadvertisingidentifier) API, see the setup guide for [AEP Consent for Edge Network](../consent-for-edge-network/README.md) for instructions on setting up the extension and profile schema for proper usage.
 {% endhint %}
 
 {% tabs %}

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -165,3 +165,29 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 ```
 {% endtab %}
 {% endtabs %}
+
+## Advertising Identifier
+The Edge Identity extension compares the previously stored advertising identifier value with the new value received from the `setAdvertisingIdentifier` API and handles the following scenarios:
+
+Ad tracking disabled - Given a valid ad ID already exists in the `IdentityMap`, and the new value  sent to the API is: 
+- `null`/`nil`
+- Empty string (`""`)
+- All-zeros string (`"00000000-0000-0000-0000-000000000000"`)  
+
+Process:
+1. Removes the ad ID from the `IdentityMap` in memory/persistence
+2. Updates the XDM shared state with the new `IdentityMap`  
+3. Sends a consent update event with ad ID consent preferences set to `no` (only when the Edge Consent extension is registered and properly configured)
+4. Ad tracking is disabled
+
+Ad tracking enabled - when the new value sent to the API is:
+- A valid string (that is, not any of the cases covered in the ad tracking disabled scenario)
+  - UUID (ex: a127a99e-50be-4d87-bf6f-6ab9541c105b)
+
+Process:
+1. Updates the `IdentityMap` in memory/persistence with the new value for IDFA/GAID
+2. Updates the XDM shared state with the new `IdentityMap`
+3. Sends a consent update event with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured) 
+4. Ad tracking is enabled
+
+No operations are executed when no changes are detected between the previously stored and new ad ID value.

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -173,7 +173,7 @@ Ad tracking enabled - when the new value sent to the API is:
 - A valid UUID string (example: `"a127a99e-50be-4d87-bf6f-6ab9541c105b"`)
 
 Process:
-1. Updates the `IdentityMap` in memory/persistence with the new value for [`IDFA`/`GAID`]. For more details see the [standard Identity namespaces](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html#standard).
+1. Updates the `IdentityMap` in memory/persistence with the new value for IDFA/GAID. For more details see the [standard Identity namespaces](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html#standard).
 2. Updates the XDM shared state with the new `IdentityMap`.
 3. Sends a consent update event with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured).
 

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -22,7 +22,6 @@ The following instructions are for configuring an application using Adobe Experi
 
 {% tabs %}
 {% tab title="Android" %}
-### Java
 
 1. Add the Mobile Core and Edge extensions to your project using the app's Gradle file.
 
@@ -30,15 +29,28 @@ The following instructions are for configuring an application using Adobe Experi
    implementation 'com.adobe.marketing.mobile:core:1.+'
    implementation 'com.adobe.marketing.mobile:edge:1.+'
    implementation 'com.adobe.marketing.mobile:edgeidentity:1.+'
+   implementation 'com.adobe.marketing.mobile:edgeconsent:1.+' // Recommended when using the setAdvertisingIdentifier API
    ```
 
 2. Import the Mobile Core and Edge extensions in your Application class.
 
-   ```java
-    import com.adobe.marketing.mobile.MobileCore;
-    import com.adobe.marketing.mobile.Edge;
-    import com.adobe.marketing.mobile.edge.identity.Identity;
-   ```
+### Java
+
+```java
+import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.Edge;
+import com.adobe.marketing.mobile.edge.identity.Identity;
+import com.adobe.marketing.mobile.edge.consent.Consent;
+```
+
+### Kotlin
+
+```kotlin
+import com.adobe.marketing.mobile.MobileCore
+import com.adobe.marketing.mobile.Edge
+import com.adobe.marketing.mobile.edge.identity.Identity
+import com.adobe.marketing.mobile.edge.consent.Consent
+```
 
 {% endtab %}
 
@@ -52,6 +64,7 @@ The following instructions are for configuring an application using Adobe Experi
        pod 'AEPCore'
        pod 'AEPEdge'
        pod 'AEPEdgeIdentity'
+       pod 'AEPEdgeConsent' // Recommended when using the setAdvertisingIdentifier API
    end
    ```
 
@@ -64,6 +77,7 @@ The following instructions are for configuring an application using Adobe Experi
 import AEPCore
 import AEPEdge
 import AEPEdgeIdentity
+import AEPEdgeConsent
 ```
 
 ### Objective-C
@@ -73,6 +87,7 @@ import AEPEdgeIdentity
 @import AEPCore;
 @import AEPEdge;
 @import AEPEdgeIdentity;
+@import AEPEdgeConsent;
 ```
 {% endtab %}
 
@@ -100,7 +115,8 @@ public class MobileApp extends Application {
       try {
         Edge.registerExtension();
         Identity.registerExtension();
-        // register other extensions
+        Consent.registerExtension();
+        // Register other extensions here
         MobileCore.start(new AdobeCallback () {
             @Override
             public void call(Object o) {
@@ -124,7 +140,7 @@ public class MobileApp extends Application {
 ```swift
 // AppDelegate.swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    MobileCore.registerExtensions([Identity.self, Edge.self], {
+    MobileCore.registerExtensions([Identity.self, Consent.self, Edge.self], {
     MobileCore.configureWith(appId: "yourLaunchEnvironmentID")
   })
   ...
@@ -136,7 +152,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 ```objectivec
 // AppDelegate.m
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [AEPMobileCore registerExtensions:@[AEPMobileEdgeIdentity.class, AEPMobileEdge.class] completion:^{
+    [AEPMobileCore registerExtensions:@[AEPMobileEdgeIdentity.class, AEPMobileEdgeConsent.class, AEPMobileEdge.class] completion:^{
     ...
   }];
   [AEPMobileCore configureWithAppId: @"yourLaunchEnvironmentID"];

--- a/foundation-extensions/identity-for-edge-network/README.md
+++ b/foundation-extensions/identity-for-edge-network/README.md
@@ -169,25 +169,22 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 ## Advertising Identifier
 The Edge Identity extension compares the previously stored advertising identifier value with the new value received from the `setAdvertisingIdentifier` API and handles the following scenarios:
 
+Ad tracking enabled - when the new value sent to the API is:
+- A valid UUID string (example: `"a127a99e-50be-4d87-bf6f-6ab9541c105b"`)
+
+Process:
+1. Updates the `IdentityMap` in memory/persistence with the new value for [`IDFA`/`GAID`]. For more details see the [standard Identity namespaces](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html#standard).
+2. Updates the XDM shared state with the new `IdentityMap`.
+3. Sends a consent update event with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured).
+
 Ad tracking disabled - Given a valid ad ID already exists in the `IdentityMap`, and the new value  sent to the API is: 
 - `null`/`nil`
 - Empty string (`""`)
 - All-zeros string (`"00000000-0000-0000-0000-000000000000"`)  
 
 Process:
-1. Removes the ad ID from the `IdentityMap` in memory/persistence
-2. Updates the XDM shared state with the new `IdentityMap`  
-3. Sends a consent update event with ad ID consent preferences set to `no` (only when the Edge Consent extension is registered and properly configured)
-4. Ad tracking is disabled
-
-Ad tracking enabled - when the new value sent to the API is:
-- A valid string (that is, not any of the cases covered in the ad tracking disabled scenario)
-  - UUID (ex: a127a99e-50be-4d87-bf6f-6ab9541c105b)
-
-Process:
-1. Updates the `IdentityMap` in memory/persistence with the new value for IDFA/GAID
-2. Updates the XDM shared state with the new `IdentityMap`
-3. Sends a consent update event with ad ID consent preferences set to `yes` (only when a valid ad ID is absent from the `IdentityMap` and the Edge Consent extension is registered and properly configured) 
-4. Ad tracking is enabled
+1. Removes the ad ID from the `IdentityMap` in memory/persistence.
+2. Updates the XDM shared state with the new `IdentityMap`.
+3. Sends a consent update event with ad ID consent preferences set to `no` (only when the Edge Consent extension is registered and properly configured).
 
 No operations are executed when no changes are detected between the previously stored and new ad ID value.

--- a/foundation-extensions/identity-for-edge-network/api-reference.md
+++ b/foundation-extensions/identity-for-edge-network/api-reference.md
@@ -359,9 +359,282 @@ The Identity for Edge Network extension does not read the Mobile SDK's privacy s
 
 See [`MobileCore.resetIdentities`](../mobile-core/mobile-core-api-reference.md#resetidentities) for more details.
 
+## setAdvertisingIdentifier
+When this API is called with a valid advertising identifier, the Identity for Edge Network extension includes the advertising identifier in the XDM Identity Map using the namespace `GAID` (Google Advertising ID) in Android and `IDFA` (Identifier for Advertisers) in iOS. If the API is called with the empty string (`""`), `null`/`nil`, or the all-zeros [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) string values, the advertising identifier is removed from the XDM Identity Map (if previously set).
+
+The advertising identifier is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall.
+
+{% tabs %}
+{% tab title="Android" %}
+
+{% hint style="warning" %} In order to enable collection of the user's current advertising tracking authorization selection for the provided advertising identifier, you need to install and register the [AEPEdgeConsent](https://aep-sdks.gitbook.io/docs/foundation-extensions/consent-for-edge-network) extension and update the [AEPEdge](https://aep-sdks.gitbook.io/docs/foundation-extensions/experience-platform-extension) dependency to minimum 1.3.2. {% endhint %}
+
+{% hint style="info" %} These examples require Google Play Services to be configured in your mobile application, and use the Google Mobile Ads Lite SDK. For instructions on how to import the SDK and configure your `ApplicationManifest.xml` file, see [Google Mobile Ads Lite SDK setup](https://developers.google.com/admob/android/lite-sdk). {% endhint %}
+
+{% hint style="info" %} These are just implementation examples. For more information about advertising identifiers and how to handle them correctly in your mobile application, see [Google Play Services documentation about AdvertisingIdClient](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient). {% endhint %}
+
+### Java
+
+**Syntax**
+
+```java
+public static void setAdvertisingIdentifier(final String advertisingIdentifier);
+```
+- _advertisingIdentifier_ is an ID string that provides developers with a simple, standard system to continue to track ads throughout their apps.
+
+**Example**
+
+```java
+...
+@Override
+public void onResume() {
+    super.onResume();
+    ...
+    new Thread(new Runnable() {
+        @Override
+        public void run() {
+            String advertisingIdentifier = null;
+
+            try {
+                AdvertisingIdClient.Info adInfo = AdvertisingIdClient.getAdvertisingIdInfo(getApplicationContext());
+                if (adInfo != null) {
+                    if (!adInfo.isLimitAdTrackingEnabled()) {
+                        advertisingIdentifier = adInfo.getId();
+                    } else {
+                        MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "Limit Ad Tracking is enabled by the user, cannot process the advertising identifier");
+                    }
+                }
+
+            } catch (IOException e) {
+                // Unrecoverable error connecting to Google Play services (e.g.,
+                // the old version of the service doesn't support getting AdvertisingId).
+                MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "IOException while retrieving the advertising identifier " + e.getLocalizedMessage());
+            } catch (GooglePlayServicesNotAvailableException e) {
+                // Google Play services is not available entirely.
+                MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "GooglePlayServicesNotAvailableException while retrieving the advertising identifier " + e.getLocalizedMessage());
+            } catch (GooglePlayServicesRepairableException e) {
+                // Google Play services is not installed, up-to-date, or enabled.
+                MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "GooglePlayServicesRepairableException while retrieving the advertising identifier " + e.getLocalizedMessage());
+            }
+
+            MobileCore.setAdvertisingIdentifier(advertisingIdentifier);
+        }
+    }).start();
+}
+```
+
+### Kotlin
+
+**Syntax**
+
+```kotlin
+public fun setAdvertisingIdentifier(advertisingIdentifier: String)
+```
+- _advertisingIdentifier_ is an ID string that provides developers with a simple, standard system to continue to track ads throughout their apps.
+
+**Example**
+
+<details>
+  <summary><code>import ...</code></summary>
+  
+```kotlin
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.ads.identifier.AdvertisingIdClient
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.common.GooglePlayServicesRepairableException
+import java.io.IOException
+```
+</details>
+
+```kotlin
+suspend fun getGAID(applicationContext: Context): String {
+    var adID = ""
+    try {
+        val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(applicationContext)
+        if (idInfo.isLimitAdTrackingEnabled) {
+            Log.d("ExampleActivity", "Limit Ad Tracking is enabled by the user, setting ad ID to \"\"")
+            return adID
+        }
+        Log.d("ExampleActivity", "Limit Ad Tracking disabled; ad ID value: ${idInfo.id}")
+        adID = idInfo.id
+    } catch (e: GooglePlayServicesNotAvailableException) {
+        Log.d("ExampleActivity", "GooglePlayServicesNotAvailableException while retrieving the advertising identifier ${e.localizedMessage}")
+    } catch (e: GooglePlayServicesRepairableException) {
+        Log.d("ExampleActivity", "GooglePlayServicesRepairableException while retrieving the advertising identifier ${e.localizedMessage}")
+    } catch (e: IOException) {
+        Log.d("ExampleActivity", "IOException while retrieving the advertising identifier ${e.localizedMessage}")
+    }
+    Log.d("ExampleActivity", "Returning ad ID value: $adID")
+    return adID
+}
+```
+Call site:
+<details>
+  <summary><code>import ...</code></summary>
+  
+```kotlin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+```
+</details>
+
+```kotlin
+ // Create background coroutine scope to fetch ad ID value
+val scope = CoroutineScope(Dispatchers.IO).launch {
+    val adID = sharedViewModel.getGAID(context.applicationContext)
+    Log.d("ExampleActivity", "Sending ad ID value: $adID to MobileCore.setAdvertisingIdentifier")
+    MobileCore.setAdvertisingIdentifier(adID)
+}
+```
+
+{% endtab %}
+
+{% tab title="iOS (AEP 3.x)" %}
+
+{% hint style="warning" %} In order to enable the collection of current advertising tracking user's selection based on the provided advertising identifier, you need to install and register the [AEPEdgeConsent](https://aep-sdks.gitbook.io/docs/foundation-extensions/consent-for-edge-network) extension and update the [AEPEdge](https://aep-sdks.gitbook.io/docs/foundation-extensions/experience-platform-extension) dependency to minimum 1.4.1. {% endhint %}
+
+{% hint style="warning" %} Starting iOS 14+, applications must use the [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency) framework to request user authorization before using the Identifier for Advertising (IDFA). To access IDFA and handle it correctly in your mobile application, see the [Apple developer documentation about IDFA](https://developer.apple.com/documentation/adsupport/asidentifiermanager). {% endhint %}
+
+### Swift
+
+**Syntax**
+
+```swift
+@objc(setAdvertisingIdentifier:)
+public static func setAdvertisingIdentifier(_ identifier: String?)
+```
+- _identifier_ is an ID string that provides developers with a simple, standard system to continue to track ads throughout their apps.
+
+**Example**
+
+```swift
+import AdSupport
+import AppTrackingTransparency
+...
+
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    ...
+    if #available(iOS 14, *) {
+       setAdvertisingIdentifierUsingTrackingManager()
+    } else {
+       // Fallback on earlier versions
+       setAdvertisingIdentifierUsingIdentifierManager()
+    }
+
+}
+
+func setAdvertisingIdentifierUsingIdentifierManager() {
+    var idfa:String = "";
+        if (ASIdentifierManager.shared().isAdvertisingTrackingEnabled) {
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString;
+        } else {
+            Log.debug(label: "AppDelegateExample",
+                      "Advertising Tracking is disabled by the user, cannot process the advertising identifier.");
+        }
+        MobileCore.setAdvertisingIdentifier(idfa);
+}
+
+@available(iOS 14, *)
+func setAdvertisingIdentifierUsingTrackingManager() {
+    ATTrackingManager.requestTrackingAuthorization { (status) in
+        var idfa: String = "";
+
+        switch (status) {
+        case .authorized:
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+        case .denied:
+            Log.debug(label: "AppDelegateExample",
+                      "Advertising Tracking is denied by the user, cannot process the advertising identifier.")
+        case .notDetermined:
+            Log.debug(label: "AppDelegateExample",
+                      "Advertising Tracking is not determined, cannot process the advertising identifier.")
+        case .restricted:
+            Log.debug(label: "AppDelegateExample",
+                      "Advertising Tracking is restricted by the user, cannot process the advertising identifier.")
+        }
+
+        MobileCore.setAdvertisingIdentifier(idfa)
+    }
+}
+```
+
+### Objective-C
+
+**Syntax**
+
+```objectivec
++ (void) setAdvertisingIdentifier: (NSString * _Nullable identifier);
+```
+
+- _identifier_ is an ID string that provides developers with a simple, standard system to continue to track ads throughout their apps.
+
+**Example**
+
+```objectivec
+#import <AdSupport/ASIdentifierManager.h>
+#import <AppTrackingTransparency/ATTrackingManager.h>
+...
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+-   ...
+-   
+    if (@available(iOS 14, *)) {
+        [self setAdvertisingIdentifierUsingTrackingManager];
+    } else {
+        // fallback to earlier versions
+        [self setAdvertisingIdentifierUsingIdentifierManager];
+    }
+
+}
+
+- (void) setAdvertisingIdentifierUsingIdentifierManager {
+    // setup the advertising identifier
+    NSString *idfa = nil;
+    if ([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
+        idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+    } else {
+        [AEPLog debugWithLabel:@"AppDelegateExample"
+                       message:@"Advertising Tracking is disabled by the user, cannot process the advertising identifier"];
+    }
+    [AEPMobileCore setAdvertisingIdentifier:idfa];
+
+}
+
+- (void) setAdvertisingIdentifierUsingTrackingManager API_AVAILABLE(ios(14)) {
+    [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:
+    ^(ATTrackingManagerAuthorizationStatus status){
+        NSString *idfa = nil;
+        switch(status) {
+            case ATTrackingManagerAuthorizationStatusAuthorized:
+                idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+                break;
+            case ATTrackingManagerAuthorizationStatusDenied:
+                [AEPLog debugWithLabel:@"AppDelegateExample"
+                               message:@"Advertising Tracking is denied by the user, cannot process the advertising identifier"];
+                break;
+            case ATTrackingManagerAuthorizationStatusNotDetermined:
+                [AEPLog debugWithLabel:@"AppDelegateExample"
+                               message:@"Advertising Tracking is not determined, cannot process the advertising identifier"];
+                break;
+            case ATTrackingManagerAuthorizationStatusRestricted:
+                [AEPLog debugWithLabel:@"AppDelegateExample"
+                               message:@"Advertising Tracking is restricted by the user, cannot process the advertising identifier"];
+                break;
+        }
+
+        [AEPMobileCore setAdvertisingIdentifier:idfa];
+    }];
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
 ## updateIdentities
 
-Update the currently known identities within the SDK. The Identity extension will merge the received identifiers with the previously saved ones in an additive manner; no identities are removed through this API.
+Update the currently known identities within the SDK. The Identity extension will merge the received identifiers with the previously saved ones in an additive manner; no identities are removed by this API.
 
 Identities with an empty _id_ or _namespace_ are not allowed and are ignored.
 

--- a/foundation-extensions/identity-for-edge-network/api-reference.md
+++ b/foundation-extensions/identity-for-edge-network/api-reference.md
@@ -360,18 +360,24 @@ The Identity for Edge Network extension does not read the Mobile SDK's privacy s
 See [`MobileCore.resetIdentities`](../mobile-core/mobile-core-api-reference.md#resetidentities) for more details.
 
 ## setAdvertisingIdentifier
-When this API is called with a valid advertising identifier, the Identity for Edge Network extension includes the advertising identifier in the XDM Identity Map using the namespace `GAID` (Google Advertising ID) in Android and `IDFA` (Identifier for Advertisers) in iOS. If the API is called with the empty string (`""`), `null`/`nil`, or the all-zeros [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) string values, the advertising identifier is removed from the XDM Identity Map (if previously set).
+When this API is called with a valid advertising identifier, the Identity for Edge Network extension includes the advertising identifier in the XDM Identity Map using the namespace `GAID` (Google Advertising ID) in Android and `IDFA` (Identifier for Advertisers) in iOS. If the API is called with the empty string (`""`), `null`/`nil`, or the all-zeros UUID string values, the advertising identifier is removed from the XDM Identity Map (if previously set).
 
 The advertising identifier is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall.
 
 {% tabs %}
 {% tab title="Android" %}
 
-{% hint style="warning" %} In order to enable collection of the user's current advertising tracking authorization selection for the provided advertising identifier, you need to install and register the [AEPEdgeConsent](https://aep-sdks.gitbook.io/docs/foundation-extensions/consent-for-edge-network) extension and update the [AEPEdge](https://aep-sdks.gitbook.io/docs/foundation-extensions/experience-platform-extension) dependency to minimum 1.3.2. {% endhint %}
+{% hint style="warning" %}
+In order to enable collection of the user's current advertising tracking authorization selection for the provided advertising identifier, you need to install and register the [AEPEdgeConsent](../consent-for-edge-network/README.md) extension and update the [AEPEdge](../experience-platform-extension/README.md) dependency to minimum 1.3.2.
+{% endhint %}
 
-{% hint style="info" %} These examples require Google Play Services to be configured in your mobile application, and use the Google Mobile Ads Lite SDK. For instructions on how to import the SDK and configure your `ApplicationManifest.xml` file, see [Google Mobile Ads Lite SDK setup](https://developers.google.com/admob/android/lite-sdk). {% endhint %}
+{% hint style="info" %}
+These examples require Google Play Services to be configured in your mobile application and use the Google Mobile Ads Lite SDK. For instructions on how to import the SDK and configure your `ApplicationManifest.xml` file see [Google Mobile Ads Lite SDK setup](https://developers.google.com/admob/android/lite-sdk).
+{% endhint %}
 
-{% hint style="info" %} These are just implementation examples. For more information about advertising identifiers and how to handle them correctly in your mobile application, see [Google Play Services documentation about AdvertisingIdClient](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient). {% endhint %}
+{% hint style="info" %}
+These are just implementation examples. For more information about advertising identifiers and how to handle them correctly in your mobile application see [Google Play Services documentation about AdvertisingIdClient](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient).
+{% endhint %}
 
 ### Java
 
@@ -433,9 +439,6 @@ public fun setAdvertisingIdentifier(advertisingIdentifier: String)
 - _advertisingIdentifier_ is an ID string that provides developers with a simple, standard system to continue to track ads throughout their apps.
 
 **Example**
-
-<details>
-  <summary><code>import ...</code></summary>
   
 ```kotlin
 import android.content.Context
@@ -444,10 +447,8 @@ import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException
 import com.google.android.gms.common.GooglePlayServicesRepairableException
 import java.io.IOException
-```
-</details>
+...
 
-```kotlin
 suspend fun getGAID(applicationContext: Context): String {
     var adID = ""
     try {
@@ -469,18 +470,15 @@ suspend fun getGAID(applicationContext: Context): String {
     return adID
 }
 ```
+
 Call site:
-<details>
-  <summary><code>import ...</code></summary>
-  
+
 ```kotlin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-```
-</details>
+...
 
-```kotlin
  // Create background coroutine scope to fetch ad ID value
 val scope = CoroutineScope(Dispatchers.IO).launch {
     val adID = sharedViewModel.getGAID(context.applicationContext)
@@ -493,9 +491,13 @@ val scope = CoroutineScope(Dispatchers.IO).launch {
 
 {% tab title="iOS (AEP 3.x)" %}
 
-{% hint style="warning" %} In order to enable the collection of current advertising tracking user's selection based on the provided advertising identifier, you need to install and register the [AEPEdgeConsent](https://aep-sdks.gitbook.io/docs/foundation-extensions/consent-for-edge-network) extension and update the [AEPEdge](https://aep-sdks.gitbook.io/docs/foundation-extensions/experience-platform-extension) dependency to minimum 1.4.1. {% endhint %}
+{% hint style="warning" %}
+In order to enable the collection of current advertising tracking user's selection based on the provided advertising identifier, you need to install and register the [AEPEdgeConsent](../consent-for-edge-network/README.md) extension and update the [AEPEdge](../experience-platform-extension/README.md) dependency to minimum 1.4.1. 
+{% endhint %}
 
-{% hint style="warning" %} Starting iOS 14+, applications must use the [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency) framework to request user authorization before using the Identifier for Advertising (IDFA). To access IDFA and handle it correctly in your mobile application, see the [Apple developer documentation about IDFA](https://developer.apple.com/documentation/adsupport/asidentifiermanager). {% endhint %}
+{% hint style="warning" %}
+Starting iOS 14+, applications must use the [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency) framework to request user authorization before using the Identifier for Advertising (IDFA). To access IDFA and handle it correctly in your mobile application, see the [Apple developer documentation about IDFA](https://developer.apple.com/documentation/adsupport/asidentifiermanager). 
+{% endhint %}
 
 ### Swift
 

--- a/foundation-extensions/identity-for-edge-network/api-reference.md
+++ b/foundation-extensions/identity-for-edge-network/api-reference.md
@@ -407,22 +407,20 @@ public void onResume() {
                     if (!adInfo.isLimitAdTrackingEnabled()) {
                         advertisingIdentifier = adInfo.getId();
                     } else {
-                        MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "Limit Ad Tracking is enabled by the user, cannot process the advertising identifier");
+                        Log.d("ExampleActivity", "Limit Ad Tracking is enabled by the user, cannot process the advertising identifier");
                     }
                 }
-
             } catch (IOException e) {
                 // Unrecoverable error connecting to Google Play services (e.g.,
                 // the old version of the service doesn't support getting AdvertisingId).
-                MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "IOException while retrieving the advertising identifier " + e.getLocalizedMessage());
+                Log.d("ExampleActivity", "IOException while retrieving the advertising identifier " + e.getLocalizedMessage());
             } catch (GooglePlayServicesNotAvailableException e) {
                 // Google Play services is not available entirely.
-                MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "GooglePlayServicesNotAvailableException while retrieving the advertising identifier " + e.getLocalizedMessage());
+                Log.d("ExampleActivity", "GooglePlayServicesNotAvailableException while retrieving the advertising identifier " + e.getLocalizedMessage());
             } catch (GooglePlayServicesRepairableException e) {
                 // Google Play services is not installed, up-to-date, or enabled.
-                MobileCore.log(LoggingMode.DEBUG, "ExampleActivity", "GooglePlayServicesRepairableException while retrieving the advertising identifier " + e.getLocalizedMessage());
+                Log.d("ExampleActivity", "GooglePlayServicesRepairableException while retrieving the advertising identifier " + e.getLocalizedMessage());
             }
-
             MobileCore.setAdvertisingIdentifier(advertisingIdentifier);
         }
     }).start();

--- a/foundation-extensions/identity-for-edge-network/api-reference.md
+++ b/foundation-extensions/identity-for-edge-network/api-reference.md
@@ -361,7 +361,7 @@ See [`MobileCore.resetIdentities`](../mobile-core/mobile-core-api-reference.md#r
 
 ## updateIdentities
 
-Update the currently known identities within the SDK. The Identity extension will merge the received identifiers with the previously saved ones in an additive manner, no identities are removed from this API.
+Update the currently known identities within the SDK. The Identity extension will merge the received identifiers with the previously saved ones in an additive manner; no identities are removed through this API.
 
 Identities with an empty _id_ or _namespace_ are not allowed and are ignored.
 


### PR DESCRIPTION
This PR updates the Identity for Edge Network extension's: 
Homepage:
- Update samples to include Consent extension

API documentation to include `setAdvertisingIdentifier`:
- Examples for Android (Java and Kotlin) and iOS (Swift and Obj-C), using the API documentation from the Identity Edge repos as the base. 

See [MOB-16626](https://jira.corp.adobe.com/browse/MOB-16626) for additional task details.