### PR TITLE
Add recommendation to marketing server key

### DIFF
--- a/using-mobile-extensions/adobe-campaignclassic/README.md
+++ b/using-mobile-extensions/adobe-campaignclassic/README.md
@@ -177,7 +177,7 @@ To update SDK configuration programmatically, use the following information to c
 | :--- | :--- | :--- | :--- |
 | `build.environment` | Yes | Specifies which environment to use (prod, dev, or staging) when sending registration and tracking information. It is also used to specify which mobile app integration key to use. | String |
 | `campaignclassic.timeout` | No | Specifies the amount of time to wait for a response from the Campaign Classic registration or tracking server. | Integer |
-| `campaignclassic.marketingServer` | Yes | Sets the marketing server, which receives registration requests. | String |
+| `campaignclassic.marketingServer` | Yes | Sets the marketing server, which receives registration requests. For reliability purposes, it is recommended to set a load-balanced URL; the mirror page URL is a suitable value. | String |
 | `campaignclassic.trackingServer` | Yes | Sets the tracking server, which receives tracking requests. | String |
 | `campaignclassic.ios.integrationKey` | Yes | Sets the iOS mobile app integration key, which links the app to an iOS application campaign in Campaign Classic. | String |
 | `campaignclassic.android.integrationKey` | Yes | Sets the Android mobile app integration key, which links the app to an Android application campaign in Campaign Classic. | String |


### PR DESCRIPTION
The campaignclassic.marketingServer key description mentions "marketing server", but that term usually designates a URL that reaches only the main server of a Campaign installation. Therefore, setting this value would not use the full benefit of the infrastructure and would potentially overload the main server. A load-balanced URL is preferable, and the mirror page URL suits well for that purpose as it is normally load-balanced to Campaign servers that have database access, which is needed for registration.