### PR TITLE
Update Bundled Rules docs to include Android details

### DIFF
--- a/foundation-extensions/mobile-core/rules-engine/README.md
+++ b/foundation-extensions/mobile-core/rules-engine/README.md
@@ -51,7 +51,7 @@ On older versions of Experience Platform Mobile SDKs \(prior to iOS version 1.6.
 
 ### Using Bundled Rules
 
-In addition to the remote configuration, you can also include a rules zip file in your app to be used by the SDK before rules have been downloaded from the Data Collection UI. This feature is supported in iOS SDK version 3.x, Android SDK version 1.9.2 onwards. To add bundled rules to your app, follow these steps:
+In addition to the remote configuration, you can also include a rules zip file in your app to be used by the SDK before rules have been downloaded from the Data Collection UI. This feature is supported in iOS SDK version 3.x, Android SDK version 1.11.2 onwards. To add bundled rules to your app, follow these steps:
 1. Download the rules zip file using the following URL: `https://assets.adobedtm.com/PASTE-ENVIRONMENT-ID-rules.zip` replacing `PASTE-ENVIRONMENT-ID` with your mobile property environment ID. 
 2. Rename the zip file to "ADBMobileConfig-rules.zip" and
    - iOS: Place the zip anywhere that it is accessible in your app bundle

--- a/foundation-extensions/mobile-core/rules-engine/README.md
+++ b/foundation-extensions/mobile-core/rules-engine/README.md
@@ -51,7 +51,11 @@ On older versions of Experience Platform Mobile SDKs \(prior to iOS version 1.6.
 
 ### Using Bundled Rules
 
-In addition to the remote configuration, you can also include a rules zip file in your app to be used by the SDK before rules have been downloaded from the Data Collection UI. This feature is supported in iOS SDK version 3.x, Android SDK version 1.11.2 onwards. To add bundled rules to your app, follow these steps:
+{% hint style="info" %}
+This feature is available from iOS AEP 3.x and Android 1.11.2
+{% endhint %}
+
+In addition to the remote configuration, you can also include a rules zip file in your app to be used by the SDK before rules have been downloaded from the Data Collection UI. To add bundled rules to your app, follow these steps:
 1. Download the rules zip file using the following URL: `https://assets.adobedtm.com/PASTE-ENVIRONMENT-ID-rules.zip` replacing `PASTE-ENVIRONMENT-ID` with your mobile property environment ID. 
 2. Rename the zip file to "ADBMobileConfig-rules.zip" and
    - iOS: Place the zip anywhere that it is accessible in your app bundle

--- a/foundation-extensions/mobile-core/rules-engine/README.md
+++ b/foundation-extensions/mobile-core/rules-engine/README.md
@@ -49,11 +49,13 @@ At the start of a new application session that includes the Experience Platform 
 
 On older versions of Experience Platform Mobile SDKs \(prior to iOS version 1.6.2, Android version 1.5.4\), after the first launch of the app, it always takes some time to download the rules from the remote servers. During this time, Rules Engine won't be able to evaluate the first several events until the rules are loaded. Starting from iOS version 1.6.2 and Android version 1.5.4, we add the capability to cache the events before the rules are downloaded and will re-evaluate those events afterward. This change is mainly to enable the trigger of Posback based on the install event.
 
-### Using Bundled Rules (iOS AEP 3.x Only)
+### Using Bundled Rules
 
-In addition to the remote configuration, you can also include a rules zip file in your app bundle to be used by the SDK before rules have been downloaded from the Data Collection UI. To add bundled rules to your app, follow these steps:
+In addition to the remote configuration, you can also include a rules zip file in your app to be used by the SDK before rules have been downloaded from the Data Collection UI. This feature is supported in iOS SDK version 3.x, Android SDK version 1.9.2 onwards. To add bundled rules to your app, follow these steps:
 1. Download the rules zip file using the following URL: `https://assets.adobedtm.com/PASTE-ENVIRONMENT-ID-rules.zip` replacing `PASTE-ENVIRONMENT-ID` with your mobile property environment ID. 
-2. Rename the zip file to "ADBMobileConfig-rules.zip" and place the zip anywhere that it is accessible in your app bundle.
+2. Rename the zip file to "ADBMobileConfig-rules.zip" and
+   - iOS: Place the zip anywhere that it is accessible in your app bundle
+   - Android: Place the zip file in the assets folder
 
 For more information about the technical details of the Rules Engine, see [Rules Engine technical details](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/rules-engine/rules-engine-details).
 


### PR DESCRIPTION
Support for bundled rules has been added from Android sdk-core v1.11.2. Updated the documentation for bundled rules to add details about file placement for Android.