### PR TITLE
Update forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ Effective March 30, 2022, support for Adobe Experience Platform Mobile SDKs on U
 
 ## Further Help
 
-* Visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk) to ask questions
+* Visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community) to ask questions
 * Contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support) for immediate assistance
 

--- a/getting-started/create-a-mobile-property.md
+++ b/getting-started/create-a-mobile-property.md
@@ -101,6 +101,6 @@ Now that you published your configuration, get the Adobe Experience Platform SDK
 
 ## Get help
 
-* To ask questions, visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk).
+* To ask questions, visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community).
 * For immediate assistance, contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support).
 

--- a/getting-started/get-the-sdk.md
+++ b/getting-started/get-the-sdk.md
@@ -684,6 +684,6 @@ To enable these permissions, add the following lines to your `AndroidManifest.xm
 
 ## Get help
 
-* Visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk) to ask questions
+* Visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community) to ask questions
 * Contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support) for immediate assistance
 

--- a/getting-started/initialize-the-sdk.md
+++ b/getting-started/initialize-the-sdk.md
@@ -454,6 +454,6 @@ For more information, see the [Mobile Core API Reference](../foundation-extensio
 
 ## Get help
 
-* Visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk) to ask questions
+* Visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community) to ask questions
 * Contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support) for immediate assistance
 

--- a/getting-started/validate.md
+++ b/getting-started/validate.md
@@ -36,6 +36,6 @@ To get started, see the **Mobile Foundations** and **Experience Cloud** sections
 
 ## Get help
 
-* Visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk) to ask questions
+* Visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community) to ask questions
 * Contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support) for immediate assistance
 

--- a/release-notes/2019.md
+++ b/release-notes/2019.md
@@ -699,5 +699,5 @@ The imports will now drop the _iOS_ suffix. Additionally, the Identity, Lifecycl
     import ACPUserProfile
 ```
 
-We feel that this update will serve our customers and partners better in the long run. If you have any questions or issues, go to our [user forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk#).
+We feel that this update will serve our customers and partners better in the long run. If you have any questions or issues, go to our [user forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community).
 

--- a/resources/frequently-asked-questions/README.md
+++ b/resources/frequently-asked-questions/README.md
@@ -134,21 +134,21 @@ See the [frequently asked questions for Analytics](../../using-mobile-extensions
 
 ## Adobe Experience Platform Edge Network
 
-### Does AEP Edge Network extension support offline tracking?
+### Does the Edge Network extension support offline tracking?
 
 Yes, offline tracking is supported by default when sending XDM Experience events since these events have a required timestamp, and there is no separate setting for this as it used to be in the Adobe Analytics extension. The events are backed up in the persistence layer and then sent to the Edge Network in current session if possible, or queued until the next session when a network connection is available.
 
 ## Get help
 
-* Visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk) to ask questions
+* Visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community) to ask questions
 * Contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support) for immediate assistance
 
-## Using AEP Swift SDKs with tvOS
+## Using Experience Platform Swift SDKs with tvOS
 
 ### 'X' is unavailable in application extension for tvOS
 
-You may encounter this error when using the AEP SDK for a tvOS app target, with the following message "'X' is unavailable in application extension for tvOS". This behavior is unexpected for tvOS targets and it seems to be an issue in Xcode where it apples additional checks for tvOSApplicationExtension API compatibility.
-Until this issue is resolved in the future Xcode versions, a workaround is to mark the classes or functions with the attribute: @available(tvOSApplicationExtension, unavailable) to suppress the error as in the examples below:
+You may encounter this error when using the Experience Platform SDK for a tvOS app target, with the following message "'X' is unavailable in application extension for tvOS". This behavior is unexpected for tvOS targets and it seems to be an issue in Xcode where it applies additional checks for `tvOSApplicationExtension` API compatibility.
+Until this issue is resolved in the future Xcode versions, a workaround is to mark the classes or functions with the attribute: `@available(tvOSApplicationExtension, unavailable)` to suppress the error as in the examples below:
 
 #### Sample
 ```Swift

--- a/resources/upgrading-to-aep/README.md
+++ b/resources/upgrading-to-aep/README.md
@@ -56,6 +56,6 @@ This client-side, SDK upgrade does not affect marketing campaigns that are in pr
 
 ## Get help
 
-* Visit the SDK [community forum](https://forums.adobe.com/community/experience-cloud/platform/launch/sdk) to ask questions
+* Visit the SDK [community forum](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/ct-p/adobe-experience-platform-community) to ask questions
 * Contact [Adobe Experience Cloud customer care](https://experienceleague.adobe.com/?support-solution=General#support) for immediate assistance
 


### PR DESCRIPTION
This PR mirrors the [updates for the Adobe IO docs](https://github.com/AdobeDocs/aep-mobile-sdkdocs/pull/182) and updates:
1. The broken forums link in FAQ page after [forums revamp](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-platform/announcement-aep-community-revamp/td-p/567039)
2. Removes some acronym usage
3. Fixes typo
4. Adds some code styling