### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ description: Welcome to the home of Adobe Experience Platform Mobile SDK documen
 {% hint style="info" %}
 ## The Mobile SDK documentation has moved!
 
-The Adobe Experience Platform Mobile SDK documentation has now moved. The latest version of the documentation can be found at https://developer.adobe.com/client-sdks/documentation/.
+The Adobe Experience Platform Mobile SDK documentation has now moved. The latest version of the documentation can be found at [https://developer.adobe.com/client-sdks/documentation/](https://developer.adobe.com/client-sdks/documentation/).
 
 {% endhint %}
 


### PR DESCRIPTION
This change converts the text URL of the new mobile SDK documentation to a hyperlink. I almost missed this redirect, since it doesn't currently stand out as a link.